### PR TITLE
ci(actions): run tests on Ubuntu and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,17 @@ jobs:
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-build
+          shared-key: ci-build-${{ matrix.os }}
       - run: cargo test


### PR DESCRIPTION
## Summary
- CI の test ジョブを matrix strategy で Ubuntu と macOS の両方で実行するように変更
- OS ごとに rust-cache の shared-key を分離し、キャッシュの衝突を防止
- `fail-fast: false` により、一方の OS が失敗しても他方のテストは継続

## Test plan
- [x] CI が Ubuntu / macOS 両方で正常に通ることを確認
- [x] rust-cache が OS ごとに独立して動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)