### PR TITLE
feat(shell): chain subcommand popup after completion confirmation

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -450,6 +450,7 @@ _zacrs_tab_complete() {
         # 末尾がスペース/スラッシュなら prev_lbuffer を更新せず
         # line-pre-redraw にチェーンさせる
         if [[ "$LBUFFER" == *[\ /] ]]; then
+            _zacrs_prev_lbuffer="$base"
             _zacrs_chain_retry=1
         else
             _zacrs_prev_lbuffer="$LBUFFER"


### PR DESCRIPTION
## Summary

- **補完確定後のチェーン表示**: Enter 確定や単一候補の自動挿入で末尾にスペース/スラッシュが付いた場合、`line-pre-redraw` が自動再トリガーしてサブコマンド候補をポップアップ表示する
- **遅延ロード補完のリトライ**: compsys が 0 件返した時に1回だけリトライし、初回で遅延ロード発火 → 2回目で結果取得。チェーン時だけでなく、手動入力のサブコマンド位置 (`uv ` 等) でも発動
- **単一候補の suffix 修正**: command/alias/builtin/function/file 系 kind に末尾スペースを追加（Rust 側 `text_with_suffix()` と一致）
- **gather fallback のガード**: 空 prefix での `*(N)` ファイルグロブを防止

## Test plan

- [ ] `g` → Tab → `go` を Enter → `go ` 後にサブコマンドポップアップが出る
- [ ] `u` → Tab → `uv` を Enter → `uv ` 後にサブコマンドポップアップが出る
- [ ] 手動で `uv ` と入力 → サブコマンドポップアップが出る（遅延ロードリトライ）
- [ ] `g` → Tab → Space → `g ` 後にポップアップが出ない（従来通り）
- [ ] `ls s` → Tab → `src/` を Enter → ディレクトリ内容のポップアップが出る
- [ ] Esc/Ctrl-C でキャンセル → ポップアップが出ない
- [ ] `cargo test` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)