### PR TITLE
fix(shell): prefer zsh/net/socket over deprecated zsh/net/unix

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -66,8 +66,8 @@ _zacrs_record_popup_snapshot() {
 # Try to load zsh/system for sysread (used by daemon complete)
 zmodload zsh/system 2>/dev/null
 
-# Try to load zsh/net/unix for zsocket support
-if zmodload zsh/net/unix 2>/dev/null; then
+# Try to load zsh/net/socket (preferred) or zsh/net/unix for zsocket support
+if zmodload zsh/net/socket 2>/dev/null || zmodload zsh/net/unix 2>/dev/null; then
     _zacrs_socket_path="${XDG_RUNTIME_DIR:-/tmp}/zacrs.sock"
     [[ -z "$XDG_RUNTIME_DIR" ]] && _zacrs_socket_path="/tmp/zacrs-${USER:-unknown}.sock"
 


### PR DESCRIPTION
## Summary

- `zsh/net/socket` を優先的にロードし、失敗時のみ `zsh/net/unix` にフォールバック
- Arch Linux 等 `net/unix.so` を同梱しないディストロでデーモンが起動しない問題を修正

## Background

`zsh/net/unix` は zsh 5.9 の man pages に記載がなく事実上 deprecated。`zsh/net/socket` が上位互換で、同じ `zsocket` API を提供する。Arch Linux (WSL2) では `net/socket.so` のみ存在し `net/unix.so` がないため、従来のコードではデーモンブロック全体がスキップされていた。

## Test plan

- [x] Arch Linux (WSL2, zsh 5.9) で `zmodload zsh/net/socket` 成功を確認
- [x] プラグイン source 後 `_zacrs_daemon_available=1` を確認
- [x] `ps aux | grep daemon` でデーモンプロセスの起動を確認
- [x] `cargo test` パス（Rust 側変更なし）

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)