### PR TITLE
fix(ui): skip popup render when filtered candidates are empty

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -486,6 +486,12 @@ impl DaemonServer {
             candidates, prefix, cursor_row, cursor_col, term_cols, term_rows, fuzzy,
         );
 
+        if app.filtered_indices.is_empty() {
+            debug!("render request had no matching candidates after filter");
+            self.fuzzy = Some(app.take_fuzzy());
+            return Response::Empty;
+        }
+
         // Cap max_visible based on terminal rows
         let max_popup_height = term_rows.saturating_sub(1);
         if app.max_visible as u16 + 2 > max_popup_height {
@@ -580,6 +586,13 @@ impl DaemonServer {
         let mut app = App::new_with_matcher(
             candidates, prefix, cursor_row, cursor_col, term_cols, term_rows, fuzzy,
         );
+
+        if app.filtered_indices.is_empty() {
+            self.fuzzy = Some(app.take_fuzzy());
+            let _ = writeln!(writer, "DONE 1 ");
+            let _ = writer.flush();
+            return;
+        }
 
         // Cap max_visible
         let max_popup_height = term_rows.saturating_sub(1);
@@ -935,6 +948,26 @@ mod tests {
             parse_complete_reuse(&["complete", "1", "2", "80", "24", "unexpected"]),
             None
         );
+    }
+
+    #[test]
+    fn handle_render_empty_after_filter_returns_empty() {
+        let mut server = test_server();
+        // Candidates exist but prefix "zzz" matches none after fuzzy filter
+        let response = server.handle_render(
+            "zzz".to_string(),
+            5,
+            2,
+            80,
+            24,
+            b"git\tcommand\tcommand\ngrep\tcommand\tcommand\n",
+        );
+
+        assert!(
+            matches!(response, crate::protocol::Response::Empty),
+            "expected Empty when no candidates match filter"
+        );
+        assert!(server.fuzzy.is_some());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,9 @@ fn run_complete(
     }
 
     let mut app = App::new(candidates, prefix, cursor_row, cursor_col);
+    if app.filtered_indices.is_empty() {
+        return Ok(1);
+    }
     let mut guard = TtyGuard::new()?;
 
     // Scroll terminal to ensure blank space below cursor for popup
@@ -168,6 +171,9 @@ fn run_render(
     }
 
     let mut app = App::new(candidates, prefix, cursor_row, cursor_col);
+    if app.filtered_indices.is_empty() {
+        return Ok(1);
+    }
 
     let mut tty = tty::open_tty_write()?;
     ui::render::ensure_space(&mut tty, &mut app)?;


### PR DESCRIPTION
## Summary

Closes #13

- `run_complete`, `run_render`, `handle_render`, `handle_complete` の4箇所で `App::new` 直後に `filtered_indices.is_empty()` ガードを追加
- フィルタ結果が空の場合、ポップアップを描画せず早期リターンする
- daemon パスでは fuzzy matcher を正しく返却

## Test plan

- [x] 新規テスト `handle_render_empty_after_filter_returns_empty` 追加（候補ありだがフィルタ後に空 → `Response::Empty`）
- [x] 既存テスト 115件全パス
- [x] `cargo clippy` / `cargo fmt --check` クリーン
- [ ] 手動: マッチしない prefix で `render` サブコマンドを実行し exit code 1 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)