### PR TITLE
fix(shell): prevent reuse of gather-derived popup on Tab

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -409,6 +409,18 @@ _zacrs_invoke_daemon() {
     local _f_popup_row _f_popup_height _f_cursor_row _f_tty_len
     if (( have_initial_frame )); then
         _zacrs_complete_parse_frame "$header"
+        # Clear stale rows from previous popup that the new frame won't cover
+        if (( _zacrs_popup_visible )); then
+            printf '\e7' >&$tty_wfd
+            local _si _row
+            for (( _si = 0; _si < _zacrs_popup_height; _si++ )); do
+                _row=$(( _zacrs_popup_row + _si ))
+                if (( _row < _f_popup_row || _row >= _f_popup_row + _f_popup_height )); then
+                    printf '\e[%d;1H\e[2K' $(( _row + 1 )) >&$tty_wfd
+                fi
+            done
+            printf '\e8' >&$tty_wfd
+        fi
         if (( _f_tty_len > 0 )); then
             sysread -i $fd -o $tty_wfd -c $_f_tty_len
         fi


### PR DESCRIPTION
## Summary
- Gather 由来の popup を Tab で再利用しないようにし、compsys を改めて実行して正しい補完テキストを挿入する
- `from_gather` フラグを snapshot / cache 層で追跡し、compsys 由来の popup は従来通りフリッカーなしで再利用
- `_zacrs_reset_cache` ヘルパーを抽出し、3 箇所のキャッシュリセットを集約

Closes #16

## Test plan
- [x] `cargo test` — 全 127 テストパス
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — クリーン
- [ ] compsys 由来の popup → Tab → フリッカーなしで再利用（既存動作維持）
- [ ] gather 由来の popup → Tab → compsys が再実行され正しいテキストが挿入される
- [ ] gather 由来の popup → Tab → compsys も失敗 → gather で再収集（フォールバック動作）
- [ ] 高速タイピング中に Tab → 文字がドロップしない

🤖 Generated with [Claude Code](https://claude.com/claude-code)