### PR TITLE
fix(ui): auto-select first candidate regardless of common prefix length

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -645,9 +645,7 @@ impl DaemonServer {
             writer.flush()
         };
 
-        if app.filter_text == app.prefix {
-            app.select_first();
-        }
+        app.select_first();
 
         let reuse_fast_path = reuse_popup && scroll_bytes.is_empty();
         let initial_frame_result =
@@ -1128,9 +1126,10 @@ mod tests {
         handle.join().unwrap();
     }
 
-    #[test]
-    fn handle_complete_confirm_with_common_prefix_returns_filter_text() {
+    fn assert_immediate_confirm(prefix: &str, candidates_tsv: &str, expected_done: &str) {
         let (server_stream, client_stream) = UnixStream::pair().unwrap();
+        let prefix = prefix.to_string();
+        let candidates_tsv = candidates_tsv.to_string();
         let handle = thread::spawn(move || {
             let mut server = test_server();
             let mut reader = BufReader::new(&server_stream);
@@ -1138,13 +1137,13 @@ mod tests {
             server.handle_complete(
                 &mut reader,
                 &mut writer,
-                "fo".to_string(),
+                prefix,
                 5,
                 2,
                 80,
                 24,
                 false,
-                "foobar\tcommand\tcommand\nfoobaz\tcommand\tcommand\n",
+                &candidates_tsv,
             );
         });
 
@@ -1155,10 +1154,28 @@ mod tests {
         send_key(&mut writer, b"\r");
         let mut done = String::new();
         reader.read_line(&mut done).unwrap();
-        assert_eq!(done.strip_suffix('\n').unwrap_or(&done), "DONE 1 fooba");
+        assert_eq!(done.strip_suffix('\n').unwrap_or(&done), expected_done);
 
         drop(reader);
         drop(writer);
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn handle_complete_confirm_with_common_prefix_selects_first() {
+        assert_immediate_confirm(
+            "fo",
+            "foobar\tcommand\tcommand\nfoobaz\tcommand\tcommand\n",
+            "DONE 0 foobar ",
+        );
+    }
+
+    #[test]
+    fn handle_complete_auto_selects_when_lcp_exceeds_prefix() {
+        assert_immediate_confirm(
+            "car",
+            "cargo\tcommand\tcommand\ncargo-add\tcommand\tcommand\n",
+            "DONE 0 cargo ",
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,9 +42,7 @@ fn run_complete(
 
     // Scroll terminal to ensure blank space below cursor for popup
     ui::render::ensure_space(&mut guard.tty, &mut app)?;
-    if app.filter_text == app.prefix {
-        app.select_first();
-    }
+    app.select_first();
     ui::render::draw(&mut guard.tty, &app, theme)?;
 
     let result = loop {


### PR DESCRIPTION
## Summary

- Tab 押下時に `select_first()` を常に呼ぶよう変更（`filter_text == prefix` ガードを除去）
- LCP（最長共通プレフィックス）がユーザー入力より長い場合（例: `car` → 候補が全部 `cargo*`）でも、最初の候補が自動選択されるようになる
- render パス（自動表示）は `select_first()` を呼ばないため影響なし

Closes #29

## Test plan

- [x] `cargo test` — 128 テスト全パス（新規2件含む）
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — クリーン
- [x] `cargo fmt --check` — クリーン
- [ ] 手動テスト: `car` → Tab → 最初の候補がハイライトされる
- [ ] 手動テスト: `c` → Tab → 既存動作維持
- [ ] 手動テスト: 入力中の auto-trigger → ハイライトなし（render パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)