### PR TITLE
fix(shell): enable chained completion popup after cycle-mode Space confirm

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -718,7 +718,8 @@ _zacrs_cycle_accept_space() {
     _zacrs_cycle_apply_selected
     LBUFFER+=" "
     _zacrs_cycle_exit
-    _zacrs_suppressed=1
+    # Chain: override _zacrs_cycle_exit の prev_lbuffer で line-pre-redraw に変化を検知させる
+    _zacrs_prev_lbuffer=""
     _zacrs_chain_retry=1
     zle reset-prompt
 }


### PR DESCRIPTION
## Summary
- サイクルモードで Space 確定後、次レベルの補完候補ポップアップが即座に表示されるように修正
- `_zacrs_cycle_accept_space` の2つのバグを修正:
  1. `_zacrs_suppressed=1` が `line-pre-redraw` のチェーンロジック到達前に early return を引き起こしていた
  2. `_zacrs_cycle_exit` が `prev_lbuffer="$LBUFFER"` をセットし、`line-pre-redraw` が変化を検知できなかった

## Test plan
- [x] `ca<Tab>` → cargo を選択 → Space → cargo サブコマンドのポップアップが即座に表示される
- [x] terraform, uv, mise など遅延ロード補完でもチェーンが動作する
- [x] Esc でキャンセル時は従来通りポップアップが消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)