### PR TITLE
fix(shell): clear stale POSTDISPLAY on cycle mode exit

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -623,6 +623,7 @@ _zacrs_cycle_exit() {
     _zacrs_cycle_active=0
     zle -K "$_zacrs_cycle_prev_keymap"
     _zacrs_clear_popup
+    unset POSTDISPLAY
     _zacrs_prev_lbuffer="$LBUFFER"
     # Release potentially large strings
     _zacrs_cycle_candidates=""


### PR DESCRIPTION
## Summary
- Tab-cycle モードで LBUFFER を変更した際（例: `car` → `cargo`）、他プラグインが設定した古い POSTDISPLAY がクリアされず、ゴーストテキストに補完差分が混入する問題を修正（例: `cargo go install --path .`）
- `_zacrs_cycle_exit` で `unset POSTDISPLAY` することで、stale な ZLE 状態を残さないようにした

## Test plan
- [ ] `car<Tab>` で `cargo` を補完後、ゴーストテキストに `go` が混入しないことを確認
- [ ] サイクルモードの各終了パス（Space 確定、Escape キャンセル、通常キー passthrough）で POSTDISPLAY が残らないことを確認
- [ ] zsh-autosuggestions 未インストール環境で副作用がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)