### PR TITLE
chore: enable LTO and single codegen-unit for bench profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ harness = false
 [profile.release]
 lto = true
 codegen-units = 1
+
+[profile.bench]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
## Summary
- Match `[profile.bench]` settings to `[profile.release]` (`lto = true`, `codegen-units = 1`)
- Benchmarks now measure performance closer to the shipped binary

Split out from #43 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)