### PR TITLE
fix(shell): don't overwrite LBUFFER on passthrough (code 3)

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -345,7 +345,9 @@ _zacrs_apply_result() {
         base="$LBUFFER"
     fi
 
-    unset POSTDISPLAY
+    # Passthrough (code 3): preserve POSTDISPLAY so zsh-autosuggestions
+    # can still accept the suggestion when the re-injected key fires.
+    [[ $result_code -ne 3 ]] && unset POSTDISPLAY
 
     if [[ $result_code -eq 0 && -n "$result_text" ]]; then
         new_lbuffer="${base}${result_text}"
@@ -354,7 +356,6 @@ _zacrs_apply_result() {
         new_lbuffer="${base}${result_text}"
         _zacrs_suppressed=0
     elif [[ $result_code -eq 3 ]]; then
-        new_lbuffer="${base}${result_text}"
         _zacrs_suppressed=0
     elif [[ $result_code -eq 1 && -n "$result_text" ]]; then
         new_lbuffer="${base}${result_text}"


### PR DESCRIPTION
## Summary
- Passthrough (result_code=3) で `_zacrs_apply_result` が 2 つの問題を起こしていた:
  1. バッファを `filter_text` (LCP自動拡張済み) で上書き → 古い autosuggestion 状態と結合して `"cargogo"` のようにテキスト重複
  2. `unset POSTDISPLAY` で autosuggestion のゴーストテキストを消去 → 再注入されたキーが autosuggestion を受け入れられない
- code=3 ではバッファも POSTDISPLAY も変更せず、元の状態を維持するように修正

## Expected flow (after fix)
1. `car` と入力 → autosuggestion が `cargo install --path .` を提案 (POSTDISPLAY = `go install --path .`)
2. Tab でポップアップに入る
3. → (右矢印) を押す → zacrs は未認識キーとしてパススルー (DONE 3)
4. シェル側: BUFFER=`"car"` / POSTDISPLAY=`"go install --path ."` を保持、右矢印を `zle -U` で再注入
5. zsh-autosuggestions の forward-char ラッパーが発動 → `"cargo install --path ."` で補完

## Test plan
- [ ] `car` + Tab + → で `cargogo` にならず、autosuggestion が正しく受け入れられることを確認
- [ ] `car` + Tab + ↓/↑ + Enter で通常の補完が正しく動作することを確認
- [ ] `car` + Tab + Escape でキャンセル時に filter_text が保持されることを確認
- [ ] Home/End/Delete 等の未認識キーでバッファが破壊されないことを確認
- [ ] `cargo test` パス
- [ ] `cargo clippy` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)