### PR TITLE
ci: add dependabot auto-merge for patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    name: Auto-Merge Patch Updates
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- dependabot が作成する patch バージョン更新 PR を CI 通過後に自動マージするワークフローを追加
- `dependabot/fetch-metadata` で semver-patch のみを判定し、`gh pr merge --auto --squash` で自動マージ
- minor / major 更新は従来どおり手動レビューを維持

## 詳細
- `pull_request_target` イベント（`opened`, `reopened` のみ）で dependabot PR を検出
- `--auto` フラグにより、必須ステータスチェック（CI, bench）通過後にマージ実行
- `concurrency`, `timeout-minutes` は既存ワークフローの規約に準拠

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>