### PR TITLE
ci: add typos spell checker to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  typos:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[default.extend-words]
+# Test data: short prefixes used in fuzzy-match / common-prefix tests
+fo = "fo"
+caf = "caf"


### PR DESCRIPTION
## Summary
- CI ワークフローに [crate-ci/typos](https://github.com/crate-ci/typos) によるスペルチェックジョブを追加
- テストデータの false positive (`fo`, `caf`) を抑制する `_typos.toml` 許可リストを追加

## Changes
- `.github/workflows/ci.yml`: `typos` ジョブを既存の lint ジョブ群 (`fmt`, `clippy`, `machete`, `test`) と並列で追加
- `_typos.toml`: fuzzy-match / common-prefix テストで使用される短い prefix 文字列の許可リスト

## Verification
- `typos` をローカル実行し、false positive なしでパスすることを確認
- `cargo fmt --check` / `cargo clippy` が引き続きパスすることを確認

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)