### PR TITLE
fix(shell): add cache-first lookup and debounce to auto-trigger path

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -949,7 +949,7 @@ _zacrs_line_pre_redraw() {
     # Rust-side filtering handles the current prefix, so the full candidate
     # list from cache is sufficient.  This eliminates per-keystroke compsys
     # overhead during rapid Backspace (same command context, shrinking prefix).
-    if [[ -n "$_zacrs_cached_candidates" ]] && (( ${#naive_prefix} >= _zacrs_cached_prefix_len )); then
+    if [[ -n "$_zacrs_cached_candidates" ]] && (( ! _zacrs_chain_retry )) && (( ${#naive_prefix} >= _zacrs_cached_prefix_len )); then
         candidates_str="$_zacrs_cached_candidates"
         from_gather=$_zacrs_cached_from_gather
         prefix="$naive_prefix"


### PR DESCRIPTION
## Summary
- Cache-first candidate lookup: `_zacrs_line_pre_redraw` で lbase 不変 + キャッシュ有効なら compsys/gather を完全スキップし、キャッシュ済み候補をそのまま Rust 側フィルタリングに渡す
- Heavy path debounce: キャッシュが無い状態（新しいコマンドコンテキスト）では `EPOCHREALTIME` ベースの 50ms スロットルで compsys の連続実行を抑制
- `zsh/datetime` モジュールの条件付きロード（利用不可な環境ではデバウンスのみ無効化）

## Background
#40 で可視フリッカーは解消済み（Synchronized Output バッチ化 + 冗長 clear 除去 + DSR スキップ）。本 PR は #26 の残課題である **不要な compsys 呼び出しの削減** と **デバウンスの導入** を対処し、Backspace 連打時の内部効率を改善する。

Closes #26

## Test plan
- [x] `cargo test` — 155 tests pass (shell-only 変更のため Rust 側への影響なし)
- [ ] Manual: `source shell/zsh-autocomplete-rs.plugin.zsh` 後、長いコマンドを入力して Backspace 連打 → ポップアップがキャッシュから即更新されることを確認
- [ ] Manual: 新しい引数位置（Space 直後）で compsys が正常に走ることを確認
- [ ] Manual: `zsh/datetime` が無い環境でエラーなく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)