### PR TITLE
fix(shell): reset candidate cache when LBUFFER is cleared

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -915,7 +915,8 @@ _zacrs_line_pre_redraw() {
     _zacrs_prev_lbuffer="$LBUFFER"
 
     # 空 or 空白のみ → コマンド未入力なのでスキップ
-    [[ ! "$LBUFFER" =~ [^[:space:]] ]] && { _zacrs_clear_popup; return }
+    # キャッシュもリセット: "cargo" → 全BS → "git" でcargoキャッシュが再利用されるバグを防ぐ
+    [[ ! "$LBUFFER" =~ [^[:space:]] ]] && { _zacrs_reset_cache; _zacrs_clear_popup; return }
 
     # DismissWithSpace 後の抑制: 非空 prefix 入力で解除 (naive prefix で十分)
     local naive_prefix="${LBUFFER##* }"


### PR DESCRIPTION
## Summary

- LBUFFER が空になったとき `_zacrs_reset_cache` を呼ぶように修正
- これにより「前のコマンド候補のキャッシュ」が次の入力に引き継がれなくなる

## Problem

`cargo` と打ってから全部 Backspace し、`git` と入力すると cargo 関係の補完候補が表示されていた。

`_zacrs_cached_candidates` はコマンド文脈（`lbase`）が変わったときだけ無効化される設計だったが、単語一語の入力では `lbase` が常に `""` のため、全 BS → 新規入力でもキャッシュが生き続けていた。

## Fix

```zsh
# before
[[ ! "$LBUFFER" =~ [^[:space:]] ]] && { _zacrs_clear_popup; return }

# after
[[ ! "$LBUFFER" =~ [^[:space:]] ]] && { _zacrs_reset_cache; _zacrs_clear_popup; return }
```

## Verification

1. `cargo` と入力 → cargo 候補が表示される
2. Backspace 5回で全消し → ポップアップが消える
3. `git` と入力 → **git 候補が正しく表示される**

Closes #79