### PR TITLE
fix(shell): use prefix string for cache-hit check to fix history nav stale candidates

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -1022,7 +1022,7 @@ _zacrs_line_pre_redraw() {
         if [[ -n "$candidates_str" ]]; then
             _zacrs_cached_candidates="$candidates_str"
             _zacrs_cached_from_gather=$from_gather
-            _zacrs_cached_prefix="$prefix"
+            _zacrs_cached_prefix="$naive_prefix"
         fi
 
         # Fuzzy fallback: 候補なし → キャッシュから再利用


### PR DESCRIPTION
## Summary

- `_zacrs_cached_prefix`（文字列）を新たに保持し、キャッシュヒット条件を prefix の**前方一致**に変更
- ヒストリナビゲーションで別のコマンドに切り替えた際に古い候補が再利用されるバグを修正

## Problem

`"cargo"` と入力後に ↑ キーで `"a"` に切り替えると、cargo 候補を `"a"` でフィルタリングした無関係な候補が表示されていた。

キャッシュヒット条件が prefix の**長さ**のみを見ていたため、ヒストリナビゲーションによる LBUFFER の原子的な書き換え（空を経由しない）を検出できなかった。

```
"cargo" → ↑ → "a":
  ${#"a"} = 1 >= _zacrs_cached_prefix_len = 1  →  TRUE（cargo 候補を再利用）
```

## Fix

```zsh
# before
(( ${#naive_prefix} >= _zacrs_cached_prefix_len ))

# after
[[ "$naive_prefix" == "${_zacrs_cached_prefix}"* ]]
```

`"a"` は `"c"` で始まらない → キャッシュミス → compsys 再実行 → 正しい候補が表示される。

## Verification

```zsh
# ヒストリに "a" を追加
a

# 1. "cargo" と入力 → cargo 候補が表示される
# 2. ↑ キー → "a" に切り替わる
# 3. a に関連する候補（または空）が表示される ← 修正後
```

## Related

- #81
- #79（同系統バグ: LBUFFER 空経由ケース）

Closes #81