### PR TITLE
fix(client): remove tty cursor query from read_session_event

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -607,11 +607,9 @@ fn read_session_event(
         if unsafe { libc::FD_ISSET(resize_fd, &readfds) } {
             drain_resize_pipe(resize_fd)?;
             let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((80, 24));
-            let (cursor_col, cursor_row) =
-                crossterm::cursor::position().unwrap_or((current_cursor_col, current_cursor_row));
             return Ok(SessionEvent::Resize {
-                cursor_row,
-                cursor_col,
+                cursor_row: current_cursor_row,
+                cursor_col: current_cursor_col,
                 term_cols,
                 term_rows,
             });


### PR DESCRIPTION
## Summary

- `read_session_event` 内の `crossterm::cursor::position()` 呼び出しを削除
- resize イベント時のカーソル位置に、引数で渡された `current_cursor_row/col` をそのまま使うよう変更

## 問題

`crossterm::cursor::position()` は端末に `\x1b[6n` を送信してレスポンスを読み取る。テスト実行中にこれが呼ばれると：

- ローカル（tty あり）: 実際のターミナルのカーソル行を返すため `assert_eq!(cursor_row, 7)` が失敗
- CI（tty なし）: 失敗して `unwrap_or` フォールバックが使われるためたまたま通過

また並列テスト実行時にエスケープシーケンスが他のテストの stdout と混在して表示が乱れる原因にもなっていた。

## 動作への影響

resize（SIGWINCH）ではカーソル位置は変わらないため、直前の値を維持しても実質的な差異はない。

## Verification

- `cargo test`: 228 passed, 0 failed（ローカル tty あり環境）
- `cargo clippy --all-targets --all-features -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)