### PR TITLE
feat(completion): add scoped command typo rescue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -302,7 +302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -534,6 +534,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "frizbee"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca1f7b0dce1c25254457f2edcfcf611bf207113564b96f90659a3f54506016b2"
+dependencies = [
+ "itertools 0.14.0",
+ "raw-cpuid",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +656,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1095,6 +1114,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "rayon"
@@ -2029,6 +2057,7 @@ dependencies = [
  "criterion",
  "crossterm",
  "dirs",
+ "frizbee",
  "libc",
  "nucleo-matcher",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zsh-autocomplete-rs"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 autobenches = false
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 libc = "0.2"
 crossterm = "0.29"
 nucleo-matcher = "0.3"
+frizbee = "0.9"
 unicode-width = "0.2"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/benches/fuzzy_bench.rs
+++ b/benches/fuzzy_bench.rs
@@ -103,6 +103,29 @@ fn filter_sequence(c: &mut Criterion) {
     group.finish();
 }
 
+fn command_typo_rescue(c: &mut Criterion) {
+    let normal_candidates = helpers::generate_realistic_command_candidates(10_000, false);
+    let rescue_candidates = helpers::generate_realistic_command_candidates(10_000, true);
+    let mut group = c.benchmark_group("command_typo_rescue");
+
+    group.bench_function("normal_prefix_cargo", |b| {
+        let mut matcher = FuzzyMatcher::new();
+        b.iter(|| matcher.filter(&normal_candidates, "cargo"));
+    });
+
+    group.bench_function("normal_typo_calude", |b| {
+        let mut matcher = FuzzyMatcher::new();
+        b.iter(|| matcher.filter(&normal_candidates, "calude"));
+    });
+
+    group.bench_function("rescue_typo_calude", |b| {
+        let mut matcher = FuzzyMatcher::new();
+        b.iter(|| matcher.filter(&rescue_candidates, "calude"));
+    });
+
+    group.finish();
+}
+
 fn app_backspace_sequence(c: &mut Criterion) {
     let candidates = helpers::generate_candidates(1_000);
     let mut group = c.benchmark_group("app_backspace_sequence");
@@ -140,6 +163,7 @@ criterion_group!(
     filter_unicode_query_variants,
     filter_unicode_scaling,
     filter_sequence,
+    command_typo_rescue,
     app_backspace_sequence
 );
 criterion_main!(benches);

--- a/benches/helpers/mod.rs
+++ b/benches/helpers/mod.rs
@@ -175,6 +175,51 @@ pub fn generate_unicode_candidates(count: usize) -> Vec<Candidate> {
     candidates
 }
 
+pub fn generate_realistic_command_candidates(count: usize, rescue: bool) -> Vec<Candidate> {
+    let mut candidates = vec![
+        Candidate {
+            text: "claude".to_string(),
+            description: "claude command".to_string(),
+            kind: command_kind(rescue),
+        },
+        Candidate {
+            text: "clang-include-fixer".to_string(),
+            description: "clang include fixer".to_string(),
+            kind: command_kind(rescue),
+        },
+        Candidate {
+            text: "clang-include-cleaner".to_string(),
+            description: "clang include cleaner".to_string(),
+            kind: command_kind(rescue),
+        },
+        Candidate {
+            text: "cargo-install-update".to_string(),
+            description: "cargo install update".to_string(),
+            kind: command_kind(rescue),
+        },
+    ];
+
+    for i in candidates.len()..count {
+        let base = COMMAND_NAMES[i % COMMAND_NAMES.len()];
+        let text = if i < COMMAND_NAMES.len() {
+            base.to_string()
+        } else {
+            format!("{}-{}", base, i / COMMAND_NAMES.len())
+        };
+        candidates.push(Candidate {
+            text,
+            description: format!("{} command", base),
+            kind: command_kind(rescue),
+        });
+    }
+
+    candidates
+}
+
+fn command_kind(rescue: bool) -> String {
+    if rescue { "command_rescue" } else { "command" }.to_string()
+}
+
 pub fn candidates_to_tsv(candidates: &[Candidate]) -> String {
     let mut tsv = String::new();
     for c in candidates {

--- a/shell/_zacrs_gather.zsh
+++ b/shell/_zacrs_gather.zsh
@@ -45,3 +45,28 @@ _zacrs_gather() {
         done
     fi
 }
+
+_zacrs_gather_command_rescue() {
+    local prefix="$1"
+    [[ ${#prefix} -lt 3 || "$prefix" == */* ]] && return
+
+    local initial="${prefix[1]}"
+    local name
+    for name in ${(k)commands}; do
+        [[ "${name[1]}" == "$initial" ]] || continue
+        printf '%s\tcommand\tcommand_rescue\n' "$name"
+    done
+    for name in ${(k)aliases}; do
+        [[ "${name[1]}" == "$initial" ]] || continue
+        printf '%s\talias\talias_rescue\n' "$name"
+    done
+    for name in ${(k)builtins}; do
+        [[ "${name[1]}" == "$initial" ]] || continue
+        printf '%s\tbuiltin\tbuiltin_rescue\n' "$name"
+    done
+    for name in ${(k)functions}; do
+        [[ "$name" == _* ]] && continue
+        [[ "${name[1]}" == "$initial" ]] || continue
+        printf '%s\tfunction\tfunction_rescue\n' "$name"
+    done
+}

--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -620,6 +620,10 @@ _zacrs_collect_candidates() {
             prefix_len=${#prefix}
         fi
     fi
+    if [[ -z "$candidates_str" && ${#prefix} -ge 3 && "$prefix" != */* ]] \
+        && _zacrs_is_cmd_pos "$LBUFFER" "$prefix"; then
+        candidates_str="$(_zacrs_gather_command_rescue "$prefix")"
+    fi
 }
 
 # Handle single-candidate immediate completion.
@@ -639,7 +643,7 @@ _zacrs_apply_single_candidate() {
     _zacrs_is_cmd_pos "$LBUFFER" "$prefix" && is_cmd_pos=1
     case "$kind" in
         directory) [[ "$text" != */ ]] && result_text+="/" ;;
-        command|alias|builtin|function|file) result_text+=" " ;;
+        command|alias|builtin|function|command_rescue|alias_rescue|builtin_rescue|function_rescue|file) result_text+=" " ;;
         "")
             if (( is_cmd_pos )) && [[ "$text" != */ && "$text" != */* ]]; then
                 result_text+=" "
@@ -918,6 +922,11 @@ _zacrs_line_pre_redraw() {
             prefix_len=${#naive_prefix}
             from_gather=1
         fi
+    fi
+    if [[ -z "$candidates_str" && ${#prefix} -ge 3 && "$prefix" != */* ]] \
+        && _zacrs_is_cmd_pos "$LBUFFER" "$prefix"; then
+        candidates_str="$(_zacrs_gather_command_rescue "$prefix")"
+        from_gather=1
     fi
 
     # Heavy path 完了後、デバウンスウィンドウを設定 (50ms)

--- a/src/candidate.rs
+++ b/src/candidate.rs
@@ -9,7 +9,7 @@ pub struct Candidate {
 
 impl Candidate {
     pub fn kind_priority(&self) -> u8 {
-        match self.kind.as_str() {
+        match self.base_kind() {
             "directory" => 0,
             "file" => 1,
             "command" => 2,
@@ -20,8 +20,16 @@ impl Candidate {
         }
     }
 
+    pub fn base_kind(&self) -> &str {
+        self.kind.strip_suffix("_rescue").unwrap_or(&self.kind)
+    }
+
+    pub fn is_typo_rescue(&self) -> bool {
+        self.kind.ends_with("_rescue")
+    }
+
     pub fn text_with_suffix(&self, suffixes: &SuffixConfig) -> String {
-        let Some(suffix) = suffixes.suffix_for_kind(&self.kind) else {
+        let Some(suffix) = suffixes.suffix_for_kind(self.base_kind()) else {
             return self.text.clone();
         };
         let base_text = self
@@ -150,6 +158,14 @@ mod tests {
     #[test]
     fn text_with_suffix_command() {
         let c = Candidate::parse_line("git\t\tcommand");
+        assert_eq!(c.text_with_suffix(&SuffixConfig::default()), "git ");
+    }
+
+    #[test]
+    fn text_with_suffix_command_rescue_uses_command_suffix() {
+        let c = Candidate::parse_line("git\t\tcommand_rescue");
+        let command = Candidate::parse_line("git\t\tcommand");
+        assert_eq!(c.kind_priority(), command.kind_priority());
         assert_eq!(c.text_with_suffix(&SuffixConfig::default()), "git ");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,14 +182,14 @@ pub(crate) fn parse_color(s: &str) -> Option<Color> {
                 n.parse::<u8>().ok().map(Color::AnsiValue)
             } else if let Some(rgb) = s.strip_prefix("rgb:") {
                 let parts: Vec<&str> = rgb.split(',').collect();
-                if parts.len() == 3 {
-                    if let (Ok(r), Ok(g), Ok(b)) = (
+                if parts.len() == 3
+                    && let (Ok(r), Ok(g), Ok(b)) = (
                         parts[0].parse::<u8>(),
                         parts[1].parse::<u8>(),
                         parts[2].parse::<u8>(),
-                    ) {
-                        return Some(Color::Rgb { r, g, b });
-                    }
+                    )
+                {
+                    return Some(Color::Rgb { r, g, b });
                 }
                 None
             } else {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -339,11 +339,11 @@ impl DaemonServer {
             self.touch_cached_key(context_key);
             return;
         }
-        if self.candidate_cache_order.len() >= CANDIDATE_CACHE_MAX_ENTRIES {
-            if let Some(oldest) = self.candidate_cache_order.first().cloned() {
-                self.candidate_cache.remove(&oldest);
-                self.candidate_cache_order.remove(0);
-            }
+        if self.candidate_cache_order.len() >= CANDIDATE_CACHE_MAX_ENTRIES
+            && let Some(oldest) = self.candidate_cache_order.first().cloned()
+        {
+            self.candidate_cache.remove(&oldest);
+            self.candidate_cache_order.remove(0);
         }
         self.candidate_cache_order.push(context_key.to_string());
         self.candidate_cache.insert(context_key.to_string(), entry);
@@ -362,11 +362,11 @@ impl DaemonServer {
             self.touch_active_popup_key(popup_key);
             return;
         }
-        if self.active_popup_order.len() >= ACTIVE_POPUP_MAX_ENTRIES {
-            if let Some(oldest) = self.active_popup_order.first().cloned() {
-                self.active_popups.remove(&oldest);
-                self.active_popup_order.remove(0);
-            }
+        if self.active_popup_order.len() >= ACTIVE_POPUP_MAX_ENTRIES
+            && let Some(oldest) = self.active_popup_order.first().cloned()
+        {
+            self.active_popups.remove(&oldest);
+            self.active_popup_order.remove(0);
         }
         self.active_popup_order.push(popup_key.to_string());
         self.active_popups.insert(popup_key.to_string(), entry);

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 
 use crate::candidate::Candidate;
+use frizbee::{Config as TypoConfig, Matcher as TypoMatcher};
 use nucleo_matcher::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher, Utf32Str};
 
@@ -74,6 +75,10 @@ impl FuzzyMatcher {
             return results;
         }
 
+        if query.chars().count() >= 3 && has_typo_rescue_candidates(candidates, fuzzy_scope) {
+            return filter_typo_rescue_matches(candidates, query, fuzzy_scope);
+        }
+
         self.ensure_pattern(query);
 
         let pattern = &self.pattern;
@@ -120,6 +125,77 @@ impl FuzzyMatcher {
             })
             .collect()
     }
+}
+
+fn has_typo_rescue_candidates(candidates: &[Candidate], fuzzy_scope: Option<&[usize]>) -> bool {
+    match fuzzy_scope {
+        Some(scope) => scope
+            .iter()
+            .any(|&candidate_idx| candidates[candidate_idx].is_typo_rescue()),
+        None => candidates.iter().any(Candidate::is_typo_rescue),
+    }
+}
+
+fn typo_rescue_max_typos(query: &str) -> u16 {
+    if query.chars().count() >= 5 { 2 } else { 1 }
+}
+
+fn filter_typo_rescue_matches(
+    candidates: &[Candidate],
+    query: &str,
+    fuzzy_scope: Option<&[usize]>,
+) -> Vec<ScoredMatch> {
+    let max_typos = typo_rescue_max_typos(query);
+    let query_len = query.chars().count();
+    let mut candidate_indices = Vec::new();
+    let mut haystacks = Vec::new();
+
+    if let Some(scope) = fuzzy_scope {
+        for &candidate_idx in scope {
+            let candidate = &candidates[candidate_idx];
+            if candidate.is_typo_rescue()
+                && candidate.text.chars().count().abs_diff(query_len) <= usize::from(max_typos)
+            {
+                candidate_indices.push(candidate_idx);
+                haystacks.push(candidate.text.as_str());
+            }
+        }
+    } else {
+        for (candidate_idx, candidate) in candidates.iter().enumerate() {
+            if candidate.is_typo_rescue()
+                && candidate.text.chars().count().abs_diff(query_len) <= usize::from(max_typos)
+            {
+                candidate_indices.push(candidate_idx);
+                haystacks.push(candidate.text.as_str());
+            }
+        }
+    }
+
+    if haystacks.is_empty() {
+        return Vec::new();
+    }
+
+    let config = TypoConfig {
+        max_typos: Some(max_typos),
+        sort: false,
+        ..TypoConfig::default()
+    };
+    let mut matcher = TypoMatcher::new(query, &config);
+    let mut results: Vec<ScoredMatch> = matcher
+        .match_iter(&haystacks)
+        .filter_map(|m| {
+            candidate_indices
+                .get(m.index as usize)
+                .copied()
+                .map(|candidate_idx| ScoredMatch {
+                    candidate_idx,
+                    score: u32::from(m.score),
+                })
+        })
+        .collect();
+
+    sort_scored_matches(&mut results, candidates);
+    results
 }
 
 fn compare_empty_candidates(a: &Candidate, b: &Candidate) -> Ordering {
@@ -192,6 +268,38 @@ mod tests {
         let candidates = make_candidates(&["foo", "bar"]);
         let results = m.filter(&candidates, "zzz");
         assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn typo_rescue_surfaces_transposed_command() {
+        let mut m = FuzzyMatcher::new();
+        let candidates = make_candidates_with_kind(&[
+            ("clang-include-fixer", "command_rescue"),
+            ("clang-include-cleaner", "command_rescue"),
+            ("cargo-install-update", "command_rescue"),
+            ("claude", "command_rescue"),
+        ]);
+
+        let results = m.filter(&candidates, "calude");
+        let texts: Vec<&str> = results.iter().map(|r| r.candidate.text.as_str()).collect();
+
+        assert_eq!(texts.first(), Some(&"claude"), "results: {texts:?}");
+    }
+
+    #[test]
+    fn typo_rescue_requires_rescue_candidate_kind() {
+        let mut m = FuzzyMatcher::new();
+        let candidates = make_candidates_with_kind(&[
+            ("clang-include-fixer", "command"),
+            ("clang-include-cleaner", "command"),
+            ("cargo-install-update", "command"),
+            ("claude", "command"),
+        ]);
+
+        let results = m.filter(&candidates, "calude");
+        let texts: Vec<&str> = results.iter().map(|r| r.candidate.text.as_str()).collect();
+
+        assert_ne!(texts.first(), Some(&"claude"), "results: {texts:?}");
     }
 
     fn make_candidates_with_kind(items: &[(&str, &str)]) -> Vec<Candidate> {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -679,7 +679,7 @@ pub fn write_text_ok(writer: &mut impl Write, metadata: &str, tty_len: usize) ->
 }
 
 pub fn decode_hex_bytes(hex: &str) -> Option<Vec<u8>> {
-    if hex.is_empty() || hex.len() % 2 != 0 {
+    if hex.is_empty() || !hex.len().is_multiple_of(2) {
         return None;
     }
 

--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -34,10 +34,10 @@ impl Popup {
         if let Some(orig_idx) = selected_original_idx {
             meta.push_str(&format!(" selected_original_idx={}", orig_idx));
         }
-        if let Some(cp) = common_prefix {
-            if is_safe_prefix(cp) {
-                meta.push_str(&format!(" common_prefix={}", cp));
-            }
+        if let Some(cp) = common_prefix
+            && is_safe_prefix(cp)
+        {
+            meta.push_str(&format!(" common_prefix={}", cp));
         }
         meta
     }


### PR DESCRIPTION
## Summary

Closes #12.

- add a command-position typo rescue candidate path that only runs after normal compsys/gather candidates are empty
- scope rescue candidates by the first typed command character instead of expanding to all commands
- mark rescue candidates with *_rescue kinds and route only those candidates through frizbee typo matching
- keep normal nucleo fuzzy matching as the default path for existing completion behavior
- add realistic fuzzy benchmarks for calude against command tables that include claude, clang-include-*, and cargo-install-update
- bump MSRV to Rust 1.88 because frizbee 0.9 uses stable let-chains unavailable in Rust 1.87 and older

## Design notes

The previous all-commands fallback let unrelated subsequence matches crowd out the intended correction. This version keeps the broad command table out of the normal path, then applies typo matching only to a scoped rescue set and filters rescue candidates by near command-name length before scoring.

frizbee remains the typo-rescue matcher. crates.io frizbee 0.4.0 through 0.8.3 did not satisfy stable Rust 1.85.1 on this path, so the smaller compatible change is raising this crate MSRV to 1.88 while keeping frizbee 0.9.

## Validation

- cargo fmt --check
- zsh -n shell/_zacrs_gather.zsh
- zsh -n shell/zsh-autocomplete-rs.plugin.zsh
- CARGO_TARGET_DIR=target cargo test
- CARGO_TARGET_DIR=target cargo clippy --all-targets --all-features -- -D warnings
- CARGO_TARGET_DIR=target cargo bench --bench fuzzy_bench -- --test
- CARGO_TARGET_DIR=target cargo +1.88.0 check --lib --bins
- CARGO_TARGET_DIR=target cargo +1.88.0 test
- Manual popup check after cargo install --path ., killing the running zsh-autocomplete-rs daemon, and sourcing shell/zsh-autocomplete-rs.plugin.zsh
- Manual typo rescue check: typing calude surfaces claude as the top command candidate, followed by scoped command suggestions such as calendar, cluster, cluttex, and ctangle