### PR TITLE
refactor(fuzzy): use frizbee for normal matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1635,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2054,5 +2078,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-normalization",
  "unicode-width",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,16 +836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nucleo-matcher"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
-dependencies = [
- "memchr",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,7 +2049,6 @@ dependencies = [
  "dirs",
  "frizbee",
  "libc",
- "nucleo-matcher",
  "serde",
  "termwiz",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "any_ascii"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c6333e01ba7235575b6ab53e5af10f1c327927fd97c36462917e289557ea64"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicode-casefold"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f66b1c8f8caa2ab31dc6d3f35386f16efdab89668f93411e565ac368908e8f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2079,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 name = "zsh-autocomplete-rs"
 version = "0.1.0"
 dependencies = [
+ "any_ascii",
  "clap",
  "criterion",
  "crossterm",
@@ -2078,6 +2091,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "unicode-casefold",
  "unicode-normalization",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ crossterm = "0.29"
 frizbee = "0.9"
 unicode-width = "0.2"
 unicode-normalization = "0.1"
+unicode-casefold = "0.2"
+any_ascii = "0.3"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2"
 crossterm = "0.29"
 frizbee = "0.9"
 unicode-width = "0.2"
+unicode-normalization = "0.1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 toml = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/main.rs"
 [dependencies]
 libc = "0.2"
 crossterm = "0.29"
-nucleo-matcher = "0.3"
 frizbee = "0.9"
 unicode-width = "0.2"
 clap = { version = "4", features = ["derive"] }

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -253,28 +253,36 @@ fn normalize_for_matching(text: &str) -> Cow<'_, str> {
 }
 
 fn normalize_case_for_matching(text: &str, fold_case: bool) -> Cow<'_, str> {
-    if !fold_case || text.is_ascii() {
+    if text.is_ascii() {
         return Cow::Borrowed(text);
     }
 
     // frizbee folds ASCII bytes only, so fold non-ASCII before matching.
-    let mut folded = String::with_capacity(text.len());
+    let mut normalized = String::with_capacity(text.len());
     let mut changed = false;
     for c in text.chars() {
         if c.is_ascii() {
-            folded.push(c);
+            normalized.push(c);
             continue;
         }
 
-        let mut chars = c.case_fold_with(Variant::Simple, Locale::NonTurkic);
-        let folded_char = chars.next().unwrap_or(c);
-        debug_assert!(chars.next().is_none());
+        let folded_char = if fold_case {
+            let mut chars = c.case_fold_with(Variant::Simple, Locale::NonTurkic);
+            let folded_char = chars.next().unwrap_or(c);
+            debug_assert!(chars.next().is_none());
+            folded_char
+        } else {
+            c
+        };
         changed |= folded_char != c;
-        folded.push(folded_char);
+        normalized.push(folded_char);
     }
 
+    let canonical: String = normalized.nfc().collect();
+    changed |= canonical != normalized;
+
     if changed {
-        Cow::Owned(folded)
+        Cow::Owned(canonical)
     } else {
         Cow::Borrowed(text)
     }
@@ -473,6 +481,43 @@ mod tests {
         assert!(plain_texts.contains(&"resume"), "results: {plain_texts:?}");
         assert!(plain_texts.contains(&"résumé"), "results: {plain_texts:?}");
         assert!(plain_texts.contains(&"RÉSUMÉ"), "results: {plain_texts:?}");
+    }
+
+    #[test]
+    fn decomposed_accented_query_matches_canonical_equivalents_only() {
+        let mut m = FuzzyMatcher::new();
+        let decomposed = "cafe\u{301}";
+        let candidates = make_candidates(&["cafe", "café", decomposed]);
+
+        let accented_results = m.filter(&candidates, decomposed);
+        let accented_texts: Vec<&str> = accented_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert!(
+            !accented_texts.contains(&"cafe"),
+            "results: {accented_texts:?}"
+        );
+        assert!(
+            accented_texts.contains(&"café"),
+            "results: {accented_texts:?}"
+        );
+        assert!(
+            accented_texts.contains(&decomposed),
+            "results: {accented_texts:?}"
+        );
+
+        let plain_results = m.filter(&candidates, "cafe");
+        let plain_texts: Vec<&str> = plain_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert!(plain_texts.contains(&"cafe"), "results: {plain_texts:?}");
+        assert!(plain_texts.contains(&"café"), "results: {plain_texts:?}");
+        assert!(
+            plain_texts.contains(&decomposed),
+            "results: {plain_texts:?}"
+        );
     }
 
     #[test]

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,15 +1,13 @@
 use std::cmp::Ordering;
 
 use crate::candidate::Candidate;
-use frizbee::{Config as TypoConfig, Matcher as TypoMatcher};
-use nucleo_matcher::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
-use nucleo_matcher::{Config, Matcher, Utf32Str};
+use frizbee::{Config as MatchConfig, Matcher};
 
 pub struct FuzzyMatcher {
     matcher: Matcher,
-    pattern: Pattern,
+    config: MatchConfig,
     last_query: String,
-    utf32_buf: Vec<char>,
+    last_max_typos: u16,
 }
 
 pub struct ScoredCandidate {
@@ -30,27 +28,28 @@ impl Default for FuzzyMatcher {
 
 impl FuzzyMatcher {
     pub fn new() -> Self {
+        let config = MatchConfig {
+            max_typos: Some(0),
+            sort: false,
+            ..MatchConfig::default()
+        };
         Self {
-            matcher: Matcher::new(Config::DEFAULT),
-            pattern: Pattern::new(
-                "",
-                CaseMatching::Smart,
-                Normalization::Smart,
-                AtomKind::Fuzzy,
-            ),
+            matcher: Matcher::new("", &config),
+            config,
             last_query: String::new(),
-            utf32_buf: Vec::new(),
+            last_max_typos: 0,
         }
     }
 
-    fn ensure_pattern(&mut self, query: &str) {
+    fn ensure_matcher(&mut self, query: &str, max_typos: u16) {
+        if self.last_max_typos != max_typos {
+            self.config.max_typos = Some(max_typos);
+            self.matcher.set_config(&self.config);
+            self.last_max_typos = max_typos;
+        }
+
         if self.last_query != query {
-            self.pattern = Pattern::new(
-                query,
-                CaseMatching::Smart,
-                Normalization::Smart,
-                AtomKind::Fuzzy,
-            );
+            self.matcher.set_needle(query);
             self.last_query.clear();
             self.last_query.push_str(query);
         }
@@ -76,44 +75,10 @@ impl FuzzyMatcher {
         }
 
         if query.chars().count() >= 3 && has_typo_rescue_candidates(candidates, fuzzy_scope) {
-            return filter_typo_rescue_matches(candidates, query, fuzzy_scope);
+            return self.filter_typo_rescue_matches(candidates, query, fuzzy_scope);
         }
 
-        self.ensure_pattern(query);
-
-        let pattern = &self.pattern;
-        let matcher = &mut self.matcher;
-        let utf32_buf = &mut self.utf32_buf;
-        let mut results: Vec<ScoredMatch> =
-            Vec::with_capacity(fuzzy_scope.map_or(candidates.len(), <[usize]>::len));
-
-        if let Some(scope) = fuzzy_scope {
-            for &candidate_idx in scope {
-                let candidate = &candidates[candidate_idx];
-                utf32_buf.clear();
-                let haystack = Utf32Str::new(&candidate.text, utf32_buf);
-                if let Some(score) = pattern.score(haystack, matcher) {
-                    results.push(ScoredMatch {
-                        candidate_idx,
-                        score,
-                    });
-                }
-            }
-        } else {
-            for (candidate_idx, candidate) in candidates.iter().enumerate() {
-                utf32_buf.clear();
-                let haystack = Utf32Str::new(&candidate.text, utf32_buf);
-                if let Some(score) = pattern.score(haystack, matcher) {
-                    results.push(ScoredMatch {
-                        candidate_idx,
-                        score,
-                    });
-                }
-            }
-        }
-
-        sort_scored_matches(&mut results, candidates);
-        results
+        self.filter_frizbee_matches(candidates, query, fuzzy_scope, 0)
     }
 
     pub fn filter(&mut self, candidates: &[Candidate], query: &str) -> Vec<ScoredCandidate> {
@@ -140,62 +105,82 @@ fn typo_rescue_max_typos(query: &str) -> u16 {
     if query.chars().count() >= 5 { 2 } else { 1 }
 }
 
-fn filter_typo_rescue_matches(
-    candidates: &[Candidate],
-    query: &str,
-    fuzzy_scope: Option<&[usize]>,
-) -> Vec<ScoredMatch> {
-    let max_typos = typo_rescue_max_typos(query);
-    let query_len = query.chars().count();
-    let mut candidate_indices = Vec::new();
-    let mut haystacks = Vec::new();
-
-    if let Some(scope) = fuzzy_scope {
-        for &candidate_idx in scope {
-            let candidate = &candidates[candidate_idx];
-            if candidate.is_typo_rescue()
-                && candidate.text.chars().count().abs_diff(query_len) <= usize::from(max_typos)
-            {
-                candidate_indices.push(candidate_idx);
-                haystacks.push(candidate.text.as_str());
-            }
-        }
-    } else {
-        for (candidate_idx, candidate) in candidates.iter().enumerate() {
-            if candidate.is_typo_rescue()
-                && candidate.text.chars().count().abs_diff(query_len) <= usize::from(max_typos)
-            {
-                candidate_indices.push(candidate_idx);
-                haystacks.push(candidate.text.as_str());
-            }
-        }
+impl FuzzyMatcher {
+    fn filter_typo_rescue_matches(
+        &mut self,
+        candidates: &[Candidate],
+        query: &str,
+        fuzzy_scope: Option<&[usize]>,
+    ) -> Vec<ScoredMatch> {
+        let max_typos = typo_rescue_max_typos(query);
+        self.filter_frizbee_matches(candidates, query, fuzzy_scope, max_typos)
     }
 
-    if haystacks.is_empty() {
-        return Vec::new();
+    fn filter_frizbee_matches(
+        &mut self,
+        candidates: &[Candidate],
+        query: &str,
+        fuzzy_scope: Option<&[usize]>,
+        max_typos: u16,
+    ) -> Vec<ScoredMatch> {
+        let query_len = query.chars().count();
+        let mut candidate_indices = Vec::new();
+        let mut haystacks = Vec::new();
+        let rescue_only = max_typos > 0;
+        let max_typos_usize = usize::from(max_typos);
+
+        if let Some(scope) = fuzzy_scope {
+            for &candidate_idx in scope {
+                let candidate = &candidates[candidate_idx];
+                if should_match_candidate(candidate, query_len, rescue_only, max_typos_usize) {
+                    candidate_indices.push(candidate_idx);
+                    haystacks.push(candidate.text.as_str());
+                }
+            }
+        } else {
+            for (candidate_idx, candidate) in candidates.iter().enumerate() {
+                if should_match_candidate(candidate, query_len, rescue_only, max_typos_usize) {
+                    candidate_indices.push(candidate_idx);
+                    haystacks.push(candidate.text.as_str());
+                }
+            }
+        }
+
+        if haystacks.is_empty() {
+            return Vec::new();
+        }
+
+        self.ensure_matcher(query, max_typos);
+        let mut results: Vec<ScoredMatch> = self
+            .matcher
+            .match_iter(&haystacks)
+            .filter_map(|m| {
+                candidate_indices
+                    .get(m.index as usize)
+                    .copied()
+                    .map(|candidate_idx| ScoredMatch {
+                        candidate_idx,
+                        score: u32::from(m.score),
+                    })
+            })
+            .collect();
+
+        sort_scored_matches(&mut results, candidates);
+        results
+    }
+}
+
+fn should_match_candidate(
+    candidate: &Candidate,
+    query_len: usize,
+    rescue_only: bool,
+    max_typos: usize,
+) -> bool {
+    if !rescue_only {
+        return true;
     }
 
-    let config = TypoConfig {
-        max_typos: Some(max_typos),
-        sort: false,
-        ..TypoConfig::default()
-    };
-    let mut matcher = TypoMatcher::new(query, &config);
-    let mut results: Vec<ScoredMatch> = matcher
-        .match_iter(&haystacks)
-        .filter_map(|m| {
-            candidate_indices
-                .get(m.index as usize)
-                .copied()
-                .map(|candidate_idx| ScoredMatch {
-                    candidate_idx,
-                    score: u32::from(m.score),
-                })
-        })
-        .collect();
-
-    sort_scored_matches(&mut results, candidates);
-    results
+    candidate.is_typo_rescue() && candidate.text.chars().count().abs_diff(query_len) <= max_typos
 }
 
 fn compare_empty_candidates(a: &Candidate, b: &Candidate) -> Ordering {

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,7 +1,9 @@
 use std::{borrow::Cow, cmp::Ordering};
 
 use crate::candidate::Candidate;
+use any_ascii::any_ascii_char;
 use frizbee::{Config as MatchConfig, Matcher};
+use unicode_casefold::{Locale, UnicodeCaseFold, Variant};
 use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 
 pub struct FuzzyMatcher {
@@ -124,15 +126,11 @@ impl FuzzyMatcher {
         fuzzy_scope: Option<&[usize]>,
         max_typos: u16,
     ) -> Vec<ScoredMatch> {
-        let normalized_query = normalize_for_matching(query);
-        let normalize_candidates = normalized_query == query;
-        let match_query = if normalize_candidates {
-            normalized_query
-        } else {
-            Cow::Borrowed(query)
-        };
-        let query_len = match_query.chars().count();
+        let normalize_candidates = normalize_for_matching(query) == query;
         let smart_case = max_typos == 0 && query.chars().any(char::is_uppercase);
+        let fold_case = !smart_case;
+        let match_query = normalize_case_for_matching(query, fold_case);
+        let query_len = match_query.chars().count();
         let mut candidate_indices = Vec::new();
         let mut haystacks = Vec::new();
         let rescue_only = max_typos > 0;
@@ -141,8 +139,11 @@ impl FuzzyMatcher {
         if let Some(scope) = fuzzy_scope {
             for &candidate_idx in scope {
                 let candidate = &candidates[candidate_idx];
-                let normalized_text =
-                    normalize_candidate_for_matching(&candidate.text, normalize_candidates);
+                let normalized_text = normalize_candidate_for_matching(
+                    &candidate.text,
+                    normalize_candidates,
+                    fold_case,
+                );
                 if should_match_candidate(
                     candidate,
                     &normalized_text,
@@ -158,8 +159,11 @@ impl FuzzyMatcher {
             }
         } else {
             for (candidate_idx, candidate) in candidates.iter().enumerate() {
-                let normalized_text =
-                    normalize_candidate_for_matching(&candidate.text, normalize_candidates);
+                let normalized_text = normalize_candidate_for_matching(
+                    &candidate.text,
+                    normalize_candidates,
+                    fold_case,
+                );
                 if should_match_candidate(
                     candidate,
                     &normalized_text,
@@ -226,16 +230,93 @@ fn normalize_for_matching(text: &str) -> Cow<'_, str> {
     if text.is_ascii() {
         Cow::Borrowed(text)
     } else {
-        Cow::Owned(text.nfd().filter(|c| !is_combining_mark(*c)).collect())
+        let mut normalized = String::with_capacity(text.len());
+        let mut changed = false;
+
+        for c in text.nfd() {
+            if is_combining_mark(c) {
+                changed = true;
+                continue;
+            }
+
+            let mapped = latin_ascii_equivalent(c);
+            changed |= mapped != c;
+            normalized.push(mapped);
+        }
+
+        if changed {
+            Cow::Owned(normalized)
+        } else {
+            Cow::Borrowed(text)
+        }
     }
 }
 
-fn normalize_candidate_for_matching(text: &str, normalize: bool) -> Cow<'_, str> {
-    if normalize {
-        normalize_for_matching(text)
+fn normalize_case_for_matching(text: &str, fold_case: bool) -> Cow<'_, str> {
+    if !fold_case || text.is_ascii() {
+        return Cow::Borrowed(text);
+    }
+
+    // frizbee folds ASCII bytes only, so fold non-ASCII before matching.
+    let mut folded = String::with_capacity(text.len());
+    let mut changed = false;
+    for c in text.chars() {
+        if c.is_ascii() {
+            folded.push(c);
+            continue;
+        }
+
+        let mut chars = c.case_fold_with(Variant::Simple, Locale::NonTurkic);
+        let folded_char = chars.next().unwrap_or(c);
+        debug_assert!(chars.next().is_none());
+        changed |= folded_char != c;
+        folded.push(folded_char);
+    }
+
+    if changed {
+        Cow::Owned(folded)
     } else {
         Cow::Borrowed(text)
     }
+}
+
+fn normalize_candidate_for_matching(text: &str, normalize: bool, fold_case: bool) -> Cow<'_, str> {
+    match (normalize, fold_case) {
+        (false, false) => Cow::Borrowed(text),
+        (false, true) => normalize_case_for_matching(text, true),
+        (true, false) => normalize_for_matching(text),
+        (true, true) => {
+            let normalized = normalize_for_matching(text);
+            match normalize_case_for_matching(&normalized, true) {
+                Cow::Borrowed(_) => normalized,
+                Cow::Owned(folded) => Cow::Owned(folded),
+            }
+        }
+    }
+}
+
+// Match Nucleo-style Latin ASCII folding without romanizing non-Latin scripts.
+fn latin_ascii_equivalent(c: char) -> char {
+    match c {
+        'ß' => 's',
+        'ẞ' => 'S',
+        _ if is_latin_ascii_fold_candidate(c) => {
+            let folded = any_ascii_char(c);
+            let mut chars = folded.chars();
+            match (chars.next(), chars.next()) {
+                (Some(ascii), None) if ascii.is_ascii_alphabetic() => ascii,
+                _ => c,
+            }
+        }
+        _ => c,
+    }
+}
+
+fn is_latin_ascii_fold_candidate(c: char) -> bool {
+    matches!(
+        c as u32,
+        0x00C0..=0x02AF | 0x1D00..=0x1EFF | 0x2071 | 0x2095..=0x209C | 0x2184
+    )
 }
 
 fn case_sensitive_subsequence_matches(query: &str, haystack: &str) -> bool {
@@ -342,9 +423,29 @@ mod tests {
     }
 
     #[test]
+    fn ascii_query_matches_non_decomposing_latin_letters() {
+        let mut m = FuzzyMatcher::new();
+        let candidates = make_candidates(&["Søren", "Łódź", "resume"]);
+
+        let soren_results = m.filter(&candidates, "soren");
+        let soren_texts: Vec<&str> = soren_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert!(soren_texts.contains(&"Søren"), "results: {soren_texts:?}");
+
+        let lodz_results = m.filter(&candidates, "lodz");
+        let lodz_texts: Vec<&str> = lodz_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert!(lodz_texts.contains(&"Łódź"), "results: {lodz_texts:?}");
+    }
+
+    #[test]
     fn accented_query_keeps_smart_normalization_asymmetric() {
         let mut m = FuzzyMatcher::new();
-        let candidates = make_candidates(&["resume", "résumé"]);
+        let candidates = make_candidates(&["resume", "résumé", "RÉSUMÉ"]);
 
         let accented_results = m.filter(&candidates, "résumé");
         let accented_texts: Vec<&str> = accented_results
@@ -359,6 +460,10 @@ mod tests {
             accented_texts.contains(&"résumé"),
             "results: {accented_texts:?}"
         );
+        assert!(
+            accented_texts.contains(&"RÉSUMÉ"),
+            "results: {accented_texts:?}"
+        );
 
         let plain_results = m.filter(&candidates, "resume");
         let plain_texts: Vec<&str> = plain_results
@@ -367,6 +472,7 @@ mod tests {
             .collect();
         assert!(plain_texts.contains(&"resume"), "results: {plain_texts:?}");
         assert!(plain_texts.contains(&"résumé"), "results: {plain_texts:?}");
+        assert!(plain_texts.contains(&"RÉSUMÉ"), "results: {plain_texts:?}");
     }
 
     #[test]

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -125,7 +125,13 @@ impl FuzzyMatcher {
         max_typos: u16,
     ) -> Vec<ScoredMatch> {
         let normalized_query = normalize_for_matching(query);
-        let query_len = normalized_query.chars().count();
+        let normalize_candidates = normalized_query == query;
+        let match_query = if normalize_candidates {
+            normalized_query
+        } else {
+            Cow::Borrowed(query)
+        };
+        let query_len = match_query.chars().count();
         let smart_case = max_typos == 0 && query.chars().any(char::is_uppercase);
         let mut candidate_indices = Vec::new();
         let mut haystacks = Vec::new();
@@ -135,11 +141,12 @@ impl FuzzyMatcher {
         if let Some(scope) = fuzzy_scope {
             for &candidate_idx in scope {
                 let candidate = &candidates[candidate_idx];
-                let normalized_text = normalize_for_matching(&candidate.text);
+                let normalized_text =
+                    normalize_candidate_for_matching(&candidate.text, normalize_candidates);
                 if should_match_candidate(
                     candidate,
                     &normalized_text,
-                    &normalized_query,
+                    &match_query,
                     query_len,
                     rescue_only,
                     max_typos_usize,
@@ -151,11 +158,12 @@ impl FuzzyMatcher {
             }
         } else {
             for (candidate_idx, candidate) in candidates.iter().enumerate() {
-                let normalized_text = normalize_for_matching(&candidate.text);
+                let normalized_text =
+                    normalize_candidate_for_matching(&candidate.text, normalize_candidates);
                 if should_match_candidate(
                     candidate,
                     &normalized_text,
-                    &normalized_query,
+                    &match_query,
                     query_len,
                     rescue_only,
                     max_typos_usize,
@@ -171,7 +179,7 @@ impl FuzzyMatcher {
             return Vec::new();
         }
 
-        self.ensure_matcher(&normalized_query, max_typos);
+        self.ensure_matcher(&match_query, max_typos);
         let mut results: Vec<ScoredMatch> = self
             .matcher
             .match_iter(&haystacks)
@@ -219,6 +227,14 @@ fn normalize_for_matching(text: &str) -> Cow<'_, str> {
         Cow::Borrowed(text)
     } else {
         Cow::Owned(text.nfd().filter(|c| !is_combining_mark(*c)).collect())
+    }
+}
+
+fn normalize_candidate_for_matching(text: &str, normalize: bool) -> Cow<'_, str> {
+    if normalize {
+        normalize_for_matching(text)
+    } else {
+        Cow::Borrowed(text)
     }
 }
 
@@ -323,6 +339,34 @@ mod tests {
             Some(&"São-Paulo"),
             "results: {sao_texts:?}"
         );
+    }
+
+    #[test]
+    fn accented_query_keeps_smart_normalization_asymmetric() {
+        let mut m = FuzzyMatcher::new();
+        let candidates = make_candidates(&["resume", "résumé"]);
+
+        let accented_results = m.filter(&candidates, "résumé");
+        let accented_texts: Vec<&str> = accented_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert!(
+            !accented_texts.contains(&"resume"),
+            "results: {accented_texts:?}"
+        );
+        assert!(
+            accented_texts.contains(&"résumé"),
+            "results: {accented_texts:?}"
+        );
+
+        let plain_results = m.filter(&candidates, "resume");
+        let plain_texts: Vec<&str> = plain_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert!(plain_texts.contains(&"resume"), "results: {plain_texts:?}");
+        assert!(plain_texts.contains(&"résumé"), "results: {plain_texts:?}");
     }
 
     #[test]

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 
 use crate::candidate::Candidate;
 use frizbee::{Config as MatchConfig, Matcher};
+use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
 
 pub struct FuzzyMatcher {
     matcher: Matcher,
@@ -123,7 +124,9 @@ impl FuzzyMatcher {
         fuzzy_scope: Option<&[usize]>,
         max_typos: u16,
     ) -> Vec<ScoredMatch> {
-        let query_len = query.chars().count();
+        let normalized_query = normalize_for_matching(query);
+        let query_len = normalized_query.chars().count();
+        let smart_case = max_typos == 0 && query.chars().any(char::is_uppercase);
         let mut candidate_indices = Vec::new();
         let mut haystacks = Vec::new();
         let rescue_only = max_typos > 0;
@@ -132,16 +135,34 @@ impl FuzzyMatcher {
         if let Some(scope) = fuzzy_scope {
             for &candidate_idx in scope {
                 let candidate = &candidates[candidate_idx];
-                if should_match_candidate(candidate, query_len, rescue_only, max_typos_usize) {
+                let normalized_text = normalize_for_matching(&candidate.text);
+                if should_match_candidate(
+                    candidate,
+                    &normalized_text,
+                    &normalized_query,
+                    query_len,
+                    rescue_only,
+                    max_typos_usize,
+                    smart_case,
+                ) {
                     candidate_indices.push(candidate_idx);
-                    haystacks.push(candidate.text.as_str());
+                    haystacks.push(normalized_text);
                 }
             }
         } else {
             for (candidate_idx, candidate) in candidates.iter().enumerate() {
-                if should_match_candidate(candidate, query_len, rescue_only, max_typos_usize) {
+                let normalized_text = normalize_for_matching(&candidate.text);
+                if should_match_candidate(
+                    candidate,
+                    &normalized_text,
+                    &normalized_query,
+                    query_len,
+                    rescue_only,
+                    max_typos_usize,
+                    smart_case,
+                ) {
                     candidate_indices.push(candidate_idx);
-                    haystacks.push(candidate.text.as_str());
+                    haystacks.push(normalized_text);
                 }
             }
         }
@@ -150,7 +171,7 @@ impl FuzzyMatcher {
             return Vec::new();
         }
 
-        self.ensure_matcher(query, max_typos);
+        self.ensure_matcher(&normalized_query, max_typos);
         let mut results: Vec<ScoredMatch> = self
             .matcher
             .match_iter(&haystacks)
@@ -172,15 +193,36 @@ impl FuzzyMatcher {
 
 fn should_match_candidate(
     candidate: &Candidate,
+    normalized_text: &str,
+    normalized_query: &str,
     query_len: usize,
     rescue_only: bool,
     max_typos: usize,
+    smart_case: bool,
 ) -> bool {
-    if !rescue_only {
-        return true;
+    if rescue_only
+        && (!candidate.is_typo_rescue()
+            || normalized_text.chars().count().abs_diff(query_len) > max_typos)
+    {
+        return false;
     }
 
-    candidate.is_typo_rescue() && candidate.text.chars().count().abs_diff(query_len) <= max_typos
+    if smart_case && !case_sensitive_subsequence_matches(normalized_query, normalized_text) {
+        return false;
+    }
+
+    true
+}
+
+fn normalize_for_matching(text: &str) -> String {
+    text.nfd().filter(|c| !is_combining_mark(*c)).collect()
+}
+
+fn case_sensitive_subsequence_matches(query: &str, haystack: &str) -> bool {
+    let mut chars = haystack.chars();
+    query
+        .chars()
+        .all(|query_char| chars.any(|c| c == query_char))
 }
 
 fn compare_empty_candidates(a: &Candidate, b: &Candidate) -> Ordering {
@@ -253,6 +295,72 @@ mod tests {
         let candidates = make_candidates(&["foo", "bar"]);
         let results = m.filter(&candidates, "zzz");
         assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn normal_matching_strips_accents() {
+        let mut m = FuzzyMatcher::new();
+        let candidates = make_candidates(&["café", "cacao", "São-Paulo"]);
+
+        let cafe_results = m.filter(&candidates, "cafe");
+        let cafe_texts: Vec<&str> = cafe_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert!(cafe_texts.contains(&"café"), "results: {cafe_texts:?}");
+
+        let sao_results = m.filter(&candidates, "sao-paulo");
+        let sao_texts: Vec<&str> = sao_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert_eq!(
+            sao_texts.first(),
+            Some(&"São-Paulo"),
+            "results: {sao_texts:?}"
+        );
+    }
+
+    #[test]
+    fn uppercase_query_filters_case_sensitively() {
+        let mut m = FuzzyMatcher::new();
+        let candidates = make_candidates(&["foo", "Foo", "FooBar", "fool"]);
+
+        let uppercase_results = m.filter(&candidates, "Foo");
+        let uppercase_texts: Vec<&str> = uppercase_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert!(
+            !uppercase_texts.contains(&"foo"),
+            "results: {uppercase_texts:?}"
+        );
+        assert!(
+            !uppercase_texts.contains(&"fool"),
+            "results: {uppercase_texts:?}"
+        );
+        assert!(
+            uppercase_texts.contains(&"Foo"),
+            "results: {uppercase_texts:?}"
+        );
+        assert!(
+            uppercase_texts.contains(&"FooBar"),
+            "results: {uppercase_texts:?}"
+        );
+
+        let lowercase_results = m.filter(&candidates, "foo");
+        let lowercase_texts: Vec<&str> = lowercase_results
+            .iter()
+            .map(|r| r.candidate.text.as_str())
+            .collect();
+        assert!(
+            lowercase_texts.contains(&"foo"),
+            "results: {lowercase_texts:?}"
+        );
+        assert!(
+            lowercase_texts.contains(&"Foo"),
+            "results: {lowercase_texts:?}"
+        );
     }
 
     #[test]

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{borrow::Cow, cmp::Ordering};
 
 use crate::candidate::Candidate;
 use frizbee::{Config as MatchConfig, Matcher};
@@ -214,8 +214,12 @@ fn should_match_candidate(
     true
 }
 
-fn normalize_for_matching(text: &str) -> String {
-    text.nfd().filter(|c| !is_combining_mark(*c)).collect()
+fn normalize_for_matching(text: &str) -> Cow<'_, str> {
+    if text.is_ascii() {
+        Cow::Borrowed(text)
+    } else {
+        Cow::Owned(text.nfd().filter(|c| !is_combining_mark(*c)).collect())
+    }
 }
 
 fn case_sensitive_subsequence_matches(query: &str, haystack: &str) -> bool {


### PR DESCRIPTION
## Summary

- route the normal fuzzy matching path through frizbee with `max_typos: Some(0)`
- preserve the old smart matching behavior by normalizing accented candidate text for plain queries, keeping accented queries strict, and keeping uppercase queries case-sensitive
- avoid allocating normalized haystacks for ASCII candidates so the compatibility layer does not regress the common path
- keep typo-rescue matching on the same frizbee path while allowing bounded typos only for `*_rescue` candidates
- remove the `nucleo-matcher` dependency from `Cargo.toml` and `Cargo.lock`

## Notes

This PR now sits on `main` after #103 was merged. `FuzzyMatcher` still reuses a matcher instance across calls and only updates the frizbee config when the typo allowance changes.

The review follow-up adds a small compatibility layer around frizbee so unaccented queries like `cafe` can still match candidates like `café`, uppercase queries like `Foo` no longer keep lowercase-only candidates such as `foo`, and accented queries like `résumé` stay strict instead of matching plain `resume`.

The benchmark-alert follow-up keeps that behavior but returns borrowed strings for ASCII text, avoiding per-candidate normalized `String` allocation in the common path.

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=target cargo test fuzzy::tests -- --nocapture`
- `CARGO_TARGET_DIR=target cargo test`
- `CARGO_TARGET_DIR=target cargo clippy --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target cargo +1.88.0 check --lib --bins`
- `CARGO_TARGET_DIR=target cargo bench --bench fuzzy_bench -- --test`
- `CARGO_TARGET_DIR=target cargo bench --bench fuzzy_bench normal_prefix_cargo`
- `CARGO_TARGET_DIR=target cargo bench --bench fuzzy_bench filter_query_variants -- --output-format bencher`
- `CARGO_TARGET_DIR=target cargo bench --bench fuzzy_bench filter_scaling -- --output-format bencher`
- `CARGO_TARGET_DIR=target cargo bench --bench fuzzy_bench command_typo_rescue -- --output-format bencher`
- `CARGO_TARGET_DIR=target cargo bench --bench fuzzy_bench filter_sequence -- --output-format bencher`
- `CARGO_TARGET_DIR=target cargo bench --bench fuzzy_bench app_backspace_sequence -- --output-format bencher`
- Manual popup check after `cargo install --path .`, killing the running `zsh-autocomplete-rs` daemon, and sourcing `shell/zsh-autocomplete-rs.plugin.zsh`
- Manual typo rescue check: typing `calude` surfaces `claude` as the top command candidate, followed by scoped command suggestions such as `calendar`, `cluster`, `cluttex`, and `ctangle`

Focused benchmark after the performance fix:

- `filter_query_variants/exact`: 12,894 ns/iter
- `filter_query_variants/no_match`: 12,687 ns/iter
- `filter_query_variants/long`: 9,886 ns/iter
- `filter_scaling/10000`: 574,691 ns/iter
- `command_typo_rescue/normal_prefix_cargo`: 424,788 ns/iter
- `command_typo_rescue/normal_typo_calude`: 123,711 ns/iter
- `command_typo_rescue/rescue_typo_calude`: 140,503 ns/iter
- `filter_sequence/full_rescan_git`: 117,248 ns/iter
- `filter_sequence/incremental_git`: 90,490 ns/iter
- `app_backspace_sequence/full_rescan_roundtrip_git`: 294,180 ns/iter

Focused benchmark before the review follow-up:

- `command_typo_rescue/normal_prefix_cargo`: 377.40 us to 383.84 us