### PR TITLE
fix(ui): satisfy Rust 1.97 clippy

### DIFF
--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -47,7 +47,7 @@ impl Popup {
         let term_rows = app.term_rows;
 
         let visible = app.visible_candidate_indices();
-        let filter_display = format!(" {} ", &app.filter_text);
+        let filter_display = format!(" {} ", app.filter_text);
 
         let max_content_width = visible
             .iter()

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -88,7 +88,7 @@ fn render_popup(buf: &mut impl Write, app: &App, theme: &Theme) -> std::io::Resu
     crossterm::queue!(buf, cursor::Hide)?;
 
     // Top border with filter text
-    let filter_label = format!(" {} ", &app.filter_text);
+    let filter_label = format!(" {} ", app.filter_text);
     let filter_w = UnicodeWidthStr::width(filter_label.as_str());
     let remaining = inner.saturating_sub(filter_w);
 


### PR DESCRIPTION
## Summary

- remove redundant references from two `format!` arguments
- restore compatibility with the `useless_borrows_in_formatting` lint enabled by Rust 1.97

## Impact

No user-visible behavior changes. This is a mechanical cleanup that restores the Clippy CI check.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target cargo test -q` (236 passed)
