### PR TITLE
fix(shell): preserve directory completion suffixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,4 +88,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci-build-${{ matrix.os }}
+      - name: Install Zsh
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y zsh
       - run: cargo test
+      - run: zsh shell/tests/compsys_options.zsh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Use a workspace-local target dir when possible:
 
 - `CARGO_TARGET_DIR=target cargo build` builds the binary at `target/debug/zsh-autocomplete-rs`.
 - `CARGO_TARGET_DIR=target cargo test` runs the unit tests embedded under `src/`.
+- `zsh shell/tests/compsys_options.zsh` runs the shell-side `compadd` option parsing regression tests.
 - `cargo fmt --check` verifies Rust formatting before review.
 - `cargo clippy --all-targets --all-features -- -D warnings` matches the CI lint configuration.
 - `cargo bench` runs Criterion benchmarks in `benches/`.

--- a/shell/_zacrs_compsys.zsh
+++ b/shell/_zacrs_compsys.zsh
@@ -50,12 +50,34 @@ _zacrs_compsys_func() {
 
         # Skip probe calls that use -O or -D (internal completion system tests)
         local _a _skip=0 _xdesc="" _vis_prefix="" _vis_suffix="" _hidden_prefix="" _is_file=0 _disp_array_name=""
-        local _prev=""
+        local _prev="" _is_option_value=0 _prev_flags="" _opt_chars="" _opt_char="" _opt_idx=0
         for _a in "$@"; do
-            if [[ "$_prev" == -[pPSXd] ]]; then
-                : # この "--" はフラグの値 → breakしない
+            _is_option_value=0
+            if (( ${#_prev} >= 2 )); then
+                _prev_flags="${_prev[2,-2]}"
+                if [[ "${_prev[-1]}" == [diIOADVJXxPSpsWFMrRE] && "${_prev_flags//[akqQfenUl12C]/}" == "" ]]; then
+                    _is_option_value=1
+                fi
+            fi
+            if (( _is_option_value )); then
+                : # この "-" / "--" はフラグの値 → breakしない
             else
-                [[ "$_a" == "--" ]] && break
+                [[ "$_a" == "-" || "$_a" == "--" ]] && break
+                if [[ "$_a" == -?* ]]; then
+                    # compadd combines short options (for example `-Qf`).
+                    # Stop at an option that consumes the rest of this argument,
+                    # so an attached value such as `-P/foo` is not scanned for `f`.
+                    _opt_chars="${_a[2,-1]}"
+                    for (( _opt_idx = 1; _opt_idx <= ${#_opt_chars}; _opt_idx++ )); do
+                        _opt_char="${_opt_chars[_opt_idx]}"
+                        case "$_opt_char" in
+                            f) _is_file=1 ;;
+                            [akqQenUl12C]) ;;
+                            [diIOADVJXxPSpsWFMrREo]) break ;;
+                            *) break ;;
+                        esac
+                    done
+                fi
             fi
             [[ "$_a" == "-O" || "$_a" == "-D" ]] && { _skip=1; break; }
             [[ "$_prev" == "-P" ]] && _vis_prefix="$_a"
@@ -63,7 +85,6 @@ _zacrs_compsys_func() {
             [[ "$_prev" == "-S" ]] && _vis_suffix="$_a"
             [[ "$_prev" == "-X" ]] && _xdesc="$_a"
             [[ "$_prev" == "-d" ]] && _disp_array_name="$_a"
-            [[ "$_a" == "-f" ]] && _is_file=1
             _prev="$_a"
         done
 

--- a/shell/_zacrs_compsys.zsh
+++ b/shell/_zacrs_compsys.zsh
@@ -29,6 +29,37 @@ _zacrs_ensure_compinit() {
     (( $+functions[_main_complete] ))
 }
 
+_zacrs_compadd_has_file_flag() {
+    local _arg _chars _char
+    local -i _idx _expect_value=0
+
+    for _arg in "$@"; do
+        if (( _expect_value )); then
+            _expect_value=0
+            continue
+        fi
+        [[ "$_arg" == "-" || "$_arg" == "--" ]] && break
+        [[ "$_arg" == -?* ]] || continue
+
+        _chars="${_arg[2,-1]}"
+        for (( _idx = 1; _idx <= ${#_chars}; _idx++ )); do
+            _char="${_chars[_idx]}"
+            case "$_char" in
+                f) return 0 ;;
+                [akqQenUl12C]) ;;
+                [diIOADVJXxPSpsWFMrRE])
+                    (( _idx == ${#_chars} )) && _expect_value=1
+                    break
+                    ;;
+                o) break ;;
+                *) break ;;
+            esac
+        done
+    done
+
+    return 1
+}
+
 _zacrs_compsys_func() {
     typeset -ga _zacrs_captured=()
     typeset -gi _zacrs_compadd_calls=0
@@ -50,7 +81,8 @@ _zacrs_compsys_func() {
 
         # Skip probe calls that use -O or -D (internal completion system tests)
         local _a _skip=0 _xdesc="" _vis_prefix="" _vis_suffix="" _hidden_prefix="" _is_file=0 _disp_array_name=""
-        local _prev="" _is_option_value=0 _prev_flags="" _opt_chars="" _opt_char="" _opt_idx=0
+        local _prev="" _is_option_value=0 _prev_flags=""
+        _zacrs_compadd_has_file_flag "$@" && _is_file=1
         for _a in "$@"; do
             _is_option_value=0
             if (( ${#_prev} >= 2 )); then
@@ -63,21 +95,6 @@ _zacrs_compsys_func() {
                 : # この "-" / "--" はフラグの値 → breakしない
             else
                 [[ "$_a" == "-" || "$_a" == "--" ]] && break
-                if [[ "$_a" == -?* ]]; then
-                    # compadd combines short options (for example `-Qf`).
-                    # Stop at an option that consumes the rest of this argument,
-                    # so an attached value such as `-P/foo` is not scanned for `f`.
-                    _opt_chars="${_a[2,-1]}"
-                    for (( _opt_idx = 1; _opt_idx <= ${#_opt_chars}; _opt_idx++ )); do
-                        _opt_char="${_opt_chars[_opt_idx]}"
-                        case "$_opt_char" in
-                            f) _is_file=1 ;;
-                            [akqQenUl12C]) ;;
-                            [diIOADVJXxPSpsWFMrREo]) break ;;
-                            *) break ;;
-                        esac
-                    done
-                fi
             fi
             [[ "$_a" == "-O" || "$_a" == "-D" ]] && { _skip=1; break; }
             [[ "$_prev" == "-P" ]] && _vis_prefix="$_a"

--- a/shell/tests/compsys_options.zsh
+++ b/shell/tests/compsys_options.zsh
@@ -1,0 +1,40 @@
+#!/usr/bin/env zsh
+
+setopt errexit nounset pipefail
+
+typeset -r test_dir=${0:A:h}
+source "${test_dir:h}/_zacrs_compsys.zsh"
+
+typeset -i failures=0
+
+assert_file_flag() {
+    local expected=$1 description=$2
+    shift 2
+
+    local actual=0
+    _zacrs_compadd_has_file_flag "$@" && actual=1
+    if (( actual != expected )); then
+        print -u2 -r -- "not ok: ${description} (expected=${expected}, actual=${actual})"
+        (( ++failures ))
+    else
+        print -r -- "ok: ${description}"
+    fi
+}
+
+assert_file_flag 1 'standalone file flag' -f candidate
+assert_file_flag 1 'combined file flag' -Qf candidate
+assert_file_flag 1 'multiple combined file flags' -QUf candidate
+assert_file_flag 1 'file flag before attached option value' -fP/foo candidate
+assert_file_flag 1 'file flag after array mode' -a -Qf array_name
+assert_file_flag 1 'file flag after associative-array mode' -k -Qf array_name
+assert_file_flag 1 'file flag after a separate option value' -i -foo -Qf candidate
+
+assert_file_flag 0 'attached prefix value containing f' -P/foo candidate
+assert_file_flag 0 'attached suffix value containing f' -Sfoo candidate
+assert_file_flag 0 'separate ignored prefix containing f' -i -foo candidate
+assert_file_flag 0 'separate ignored suffix containing f' -I -foo candidate
+assert_file_flag 0 'value after combined suffix option containing f' -Qs -foo candidate
+assert_file_flag 0 'candidate after option terminator' - -foo
+assert_file_flag 0 'candidate after double option terminator' -- -foo
+
+(( failures == 0 ))


### PR DESCRIPTION
## Summary

- recognize `compadd` file flags when they are combined with other short options such as `-Qf`
- parse attached and separate option values without mistaking their contents for file flags
- honor both `-` and `--` option terminators
- add shell regression coverage and run it on Linux and macOS CI

## User-visible behavior

Selecting a directory from popup completion now preserves directory classification, so the configured `/` suffix is inserted instead of a trailing space. Regular files continue to receive the normal space suffix.

## Root cause

The shell integration only recognized a standalone `compadd -f`. Zsh's completion functions commonly combine flags, including `-Qf`, which caused filesystem candidates to lose their file/directory kind.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target cargo test -q` (236 passed)
- `zsh shell/tests/compsys_options.zsh` (14 cases passed)
- `zsh -n shell/_zacrs_compsys.zsh shell/zsh-autocomplete-rs.plugin.zsh shell/tests/compsys_options.zsh`
- manual popup check: selecting `src/` after `cat` inserts `src/`
