### PR TITLE
fix(shell): classify tilde-prefixed paths

### DIFF
--- a/shell/_zacrs_compsys.zsh
+++ b/shell/_zacrs_compsys.zsh
@@ -60,6 +60,20 @@ _zacrs_compadd_has_file_flag() {
     return 1
 }
 
+_zacrs_path_candidate_kind() {
+    local _path="$1"
+    case "$_path" in
+        '~') _path="$HOME" ;;
+        '~/'*) _path="${HOME}${_path[2,-1]}" ;;
+    esac
+
+    if [[ -d "$_path" ]]; then
+        REPLY="directory"
+    else
+        REPLY="file"
+    fi
+}
+
 _zacrs_compsys_func() {
     typeset -ga _zacrs_captured=()
     typeset -gi _zacrs_compadd_calls=0
@@ -131,7 +145,8 @@ _zacrs_compsys_func() {
                 local _text="${_full_prefix}${_m}${_vis_suffix}"
                 local _kind=""
                 if (( _is_file )); then
-                    [[ -d "${_full_prefix}${_m}" ]] && _kind="directory" || _kind="file"
+                    _zacrs_path_candidate_kind "${_full_prefix}${_m}"
+                    _kind="$REPLY"
                 elif [[ "$_text" == */ ]]; then
                     _kind="directory"
                 elif (( _zacrs_cmd_pos )) && [[ "$_text" != */* ]] && _zacrs_command_kind "$_m"; then

--- a/shell/tests/compsys_options.zsh
+++ b/shell/tests/compsys_options.zsh
@@ -37,4 +37,20 @@ assert_file_flag 0 'value after combined suffix option containing f' -Qs -foo ca
 assert_file_flag 0 'candidate after option terminator' - -foo
 assert_file_flag 0 'candidate after double option terminator' -- -foo
 
+assert_path_kind() {
+    local expected=$1 path=$2 description=$3
+    _zacrs_path_candidate_kind "$path"
+    if [[ "$REPLY" != "$expected" ]]; then
+        print -u2 -r -- "not ok: ${description} (expected=${expected}, actual=${REPLY})"
+        (( ++failures ))
+    else
+        print -r -- "ok: ${description}"
+    fi
+}
+
+assert_path_kind directory "$test_dir" 'directory candidate keeps directory kind'
+assert_path_kind file "$0" 'file candidate keeps file kind'
+HOME="$test_dir" assert_path_kind directory '~/' 'home-relative directory candidate keeps directory kind'
+HOME="$test_dir" assert_path_kind file '~/compsys_options.zsh' 'home-relative file candidate keeps file kind'
+
 (( failures == 0 ))

--- a/src/candidate.rs
+++ b/src/candidate.rs
@@ -162,6 +162,22 @@ mod tests {
     }
 
     #[test]
+    fn text_with_suffix_file_keeps_path_and_appends_file_suffix() {
+        let c = Candidate::parse_line("notes.txt\t\tfile");
+        assert_eq!(c.text_with_suffix(&SuffixConfig::default()), "notes.txt ");
+    }
+
+    #[test]
+    fn path_kinds_keep_file_and_directory_suffixes_distinct() {
+        let directory = Candidate::parse_line("src\t\tdirectory");
+        let file = Candidate::parse_line("src/main.rs\t\tfile");
+        let suffixes = SuffixConfig::default();
+
+        assert_eq!(directory.text_with_suffix(&suffixes), "src/");
+        assert_eq!(file.text_with_suffix(&suffixes), "src/main.rs ");
+    }
+
+    #[test]
     fn text_with_suffix_command_rescue_uses_command_suffix() {
         let c = Candidate::parse_line("git\t\tcommand_rescue");
         let command = Candidate::parse_line("git\t\tcommand");


### PR DESCRIPTION
## What changed

- Expand leading `~` and `~/` to `$HOME` when classifying captured path candidates.
- Keep candidate text unchanged for insertion and display.
- Add shell regressions for regular and home-relative directory/file classification.
- Pin the existing directory `/` and file-space suffix behavior in Rust tests.

## Why

Zsh does not perform tilde expansion on a path after it has been stored in a parameter. The quoted `[[ -d ... ]]` check therefore treated directories such as `~/src` as files, so completion did not append `/`.

The new helper resolves only the supported home-relative forms before checking the filesystem. It does not use `eval`, glob expansion, or command substitution.

## User impact

Directories completed through `~/...` retain the `directory` kind and receive a trailing `/`. Files retain the `file` kind and receive the configured file suffix.

## Validation

- `CARGO_TARGET_DIR=target cargo clippy --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target cargo test -q` (238 passed)
- `zsh shell/tests/compsys_options.zsh`
- `zsh -n shell/_zacrs_compsys.zsh shell/tests/compsys_options.zsh`
- Manual verification of `~/...` directory completion
