### PR TITLE
feat(completion): add portable abbreviations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,4 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zsh
       - run: cargo test
       - run: zsh shell/tests/compsys_options.zsh
+      - run: zsh shell/tests/protocol.zsh

--- a/benches/fuzzy_bench.rs
+++ b/benches/fuzzy_bench.rs
@@ -1,7 +1,9 @@
 mod helpers;
 
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use zsh_autocomplete_rs::app::App;
+use zsh_autocomplete_rs::candidate::Candidate;
+use zsh_autocomplete_rs::config::Abbreviation;
 use zsh_autocomplete_rs::fuzzy::FuzzyMatcher;
 
 fn filter_scaling(c: &mut Criterion) {
@@ -126,6 +128,45 @@ fn command_typo_rescue(c: &mut Criterion) {
     group.finish();
 }
 
+fn abbreviation_injection_and_filter(c: &mut Criterion) {
+    let native_candidates = helpers::generate_candidates(1_000);
+    let mut group = c.benchmark_group("abbreviation_injection_and_filter");
+
+    for abbreviation_count in [0, 100, 1_000] {
+        let abbreviations: Vec<_> = (0..abbreviation_count)
+            .map(|index| Abbreviation {
+                trigger: format!("abbr-{index}"),
+                expansion: format!("command-{index} --option '{{{{cursor}}}}'"),
+                description: format!("user abbreviation {index}"),
+            })
+            .collect();
+        let mut matcher = FuzzyMatcher::new();
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(abbreviation_count),
+            &abbreviations,
+            |b, abbreviations| {
+                b.iter_batched(
+                    || native_candidates.clone(),
+                    |mut candidates| {
+                        candidates.extend(abbreviations.iter().map(|abbr| {
+                            Candidate::abbreviation(
+                                abbr.trigger.clone(),
+                                abbr.expansion.clone(),
+                                abbr.description.clone(),
+                            )
+                        }));
+                        matcher.filter(&candidates, "abbr")
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn app_backspace_sequence(c: &mut Criterion) {
     let candidates = helpers::generate_candidates(1_000);
     let mut group = c.benchmark_group("app_backspace_sequence");
@@ -164,6 +205,7 @@ criterion_group!(
     filter_unicode_scaling,
     filter_sequence,
     command_typo_rescue,
+    abbreviation_injection_and_filter,
     app_backspace_sequence
 );
 criterion_main!(benches);

--- a/benches/helpers/mod.rs
+++ b/benches/helpers/mod.rs
@@ -143,6 +143,8 @@ pub fn generate_candidates(count: usize) -> Vec<Candidate> {
             text,
             description,
             kind,
+            insert_text: None,
+            cursor_offset: None,
         });
     }
     candidates
@@ -170,6 +172,8 @@ pub fn generate_unicode_candidates(count: usize) -> Vec<Candidate> {
             text,
             description,
             kind,
+            insert_text: None,
+            cursor_offset: None,
         });
     }
     candidates
@@ -181,21 +185,29 @@ pub fn generate_realistic_command_candidates(count: usize, rescue: bool) -> Vec<
             text: "claude".to_string(),
             description: "claude command".to_string(),
             kind: command_kind(rescue),
+            insert_text: None,
+            cursor_offset: None,
         },
         Candidate {
             text: "clang-include-fixer".to_string(),
             description: "clang include fixer".to_string(),
             kind: command_kind(rescue),
+            insert_text: None,
+            cursor_offset: None,
         },
         Candidate {
             text: "clang-include-cleaner".to_string(),
             description: "clang include cleaner".to_string(),
             kind: command_kind(rescue),
+            insert_text: None,
+            cursor_offset: None,
         },
         Candidate {
             text: "cargo-install-update".to_string(),
             description: "cargo install update".to_string(),
             kind: command_kind(rescue),
+            insert_text: None,
+            cursor_offset: None,
         },
     ];
 
@@ -210,6 +222,8 @@ pub fn generate_realistic_command_candidates(count: usize, rescue: bool) -> Vec<
             text,
             description: format!("{} command", base),
             kind: command_kind(rescue),
+            insert_text: None,
+            cursor_offset: None,
         });
     }
 
@@ -243,6 +257,8 @@ pub fn generate_prefixed_candidates(prefix: &str, count: usize) -> Vec<Candidate
             text,
             description: String::new(),
             kind: "command".to_string(),
+            insert_text: None,
+            cursor_offset: None,
         });
     }
     candidates
@@ -293,6 +309,8 @@ pub fn generate_cjk_candidates(count: usize) -> Vec<Candidate> {
             text,
             description,
             kind,
+            insert_text: None,
+            cursor_offset: None,
         });
     }
     candidates
@@ -311,6 +329,8 @@ pub fn generate_no_description_candidates(count: usize) -> Vec<Candidate> {
             text,
             description: String::new(),
             kind: "command".to_string(),
+            insert_text: None,
+            cursor_offset: None,
         });
     }
     candidates
@@ -335,6 +355,8 @@ pub fn generate_long_description_candidates(count: usize) -> Vec<Candidate> {
             text,
             description,
             kind: "command".to_string(),
+            insert_text: None,
+            cursor_offset: None,
         });
     }
     candidates

--- a/benches/protocol_bench.rs
+++ b/benches/protocol_bench.rs
@@ -30,6 +30,7 @@ fn make_render_request(candidate_count: usize) -> Request {
         term_rows: 24,
         candidates_tsv: tsv,
         selected: Some(0),
+        command_position: false,
     }
 }
 

--- a/benches/rendering_bench.rs
+++ b/benches/rendering_bench.rs
@@ -133,6 +133,8 @@ fn bench_layout_candidate(c: &mut Criterion) {
             text: "cargo-build".to_string(),
             description: "compile the current package".to_string(),
             kind: "command".to_string(),
+            insert_text: None,
+            cursor_offset: None,
         };
         group.bench_with_input(
             BenchmarkId::from_parameter("ascii_with_desc"),
@@ -148,6 +150,8 @@ fn bench_layout_candidate(c: &mut Criterion) {
             text: "cargo-build".to_string(),
             description: String::new(),
             kind: "command".to_string(),
+            insert_text: None,
+            cursor_offset: None,
         };
         group.bench_with_input(
             BenchmarkId::from_parameter("ascii_no_desc"),
@@ -163,6 +167,8 @@ fn bench_layout_candidate(c: &mut Criterion) {
             text: "ファイル一覧表示".to_string(),
             description: "ディレクトリの内容を表示するコマンド".to_string(),
             kind: "command".to_string(),
+            insert_text: None,
+            cursor_offset: None,
         };
         group.bench_with_input(
             BenchmarkId::from_parameter("cjk_with_desc"),
@@ -178,6 +184,8 @@ fn bench_layout_candidate(c: &mut Criterion) {
             text: "ファイル一覧表示".to_string(),
             description: String::new(),
             kind: "command".to_string(),
+            insert_text: None,
+            cursor_offset: None,
         };
         group.bench_with_input(
             BenchmarkId::from_parameter("cjk_no_desc"),
@@ -193,6 +201,8 @@ fn bench_layout_candidate(c: &mut Criterion) {
             text: "git-ブランチ一覧".to_string(),
             description: "list all branches ブランチ表示".to_string(),
             kind: "command".to_string(),
+            insert_text: None,
+            cursor_offset: None,
         };
         group.bench_with_input(
             BenchmarkId::from_parameter("mixed_with_desc"),
@@ -210,6 +220,8 @@ fn bench_layout_candidate(c: &mut Criterion) {
                           and optimizations applied across the entire workspace"
                 .to_string(),
             kind: "command".to_string(),
+            insert_text: None,
+            cursor_offset: None,
         };
         group.bench_with_input(
             BenchmarkId::from_parameter("long_desc_truncation"),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,46 @@
+# Configuration
+
+The configuration file is read from `$XDG_CONFIG_HOME/zacrs/config.toml`, or
+`~/.config/zacrs/config.toml` when `XDG_CONFIG_HOME` is not set.
+
+## Abbreviations
+
+Static abbreviations are portable completion candidates. They are offered only
+at command position, and their expansion is inserted literally without running
+shell evaluation while candidates are being gathered or displayed.
+
+For simple entries, use the `[abbreviations]` table:
+
+```toml
+[abbreviations]
+gs = "git status"
+```
+
+For a description or explicit cursor placement, use `[[abbreviation]]`:
+
+```toml
+[[abbreviation]]
+trigger = "gcm"
+expansion = "git commit -m '{{cursor}}'"
+description = "commit with a message"
+scope = "command"
+```
+
+`{{cursor}}` is removed during insertion and places the cursor at that position.
+Only one cursor marker is supported per expansion.
+
+The popup description always starts with the literal expansion preview. When a
+custom `description` is configured, it is shown after the preview.
+
+When an abbreviation is selected in the popup:
+
+- Enter expands it and accepts the command line.
+- Space expands it, appends a space, and keeps editing the command line.
+- Cancel leaves the command line unchanged.
+
+Defining abbreviations does not install key bindings, widgets, hooks, aliases,
+functions, or traps. The shell adapter remains responsible for presenting and
+applying completion results.
+
+Both the daemon and subprocess paths read the same configuration. A running
+daemon reloads the file when its modification time changes.

--- a/shell/_zacrs_protocol.zsh
+++ b/shell/_zacrs_protocol.zsh
@@ -1,0 +1,46 @@
+# Helpers for decoding and parsing the shell-facing completion result protocol.
+
+_zacrs_decode_hex_to_REPLY() {
+    local hex="$1"
+    REPLY=""
+    [[ -z "$hex" ]] && return 0
+    (( ${#hex} % 2 == 0 )) || return 1
+
+    local escaped="" i pair
+    for (( i = 1; i <= ${#hex}; i += 2 )); do
+        pair="${hex[i,i+1]}"
+        [[ "$pair" == [[:xdigit:]][[:xdigit:]] ]] || return 1
+        escaped+="\\x${pair}"
+    done
+    printf -v REPLY '%b' "$escaped"
+}
+
+_zacrs_parse_apply_line() {
+    local apply_line="$1"
+    local metadata="$apply_line"
+    chain=0
+    execute=0
+    restore_text=""
+    cursor_offset=""
+
+    if [[ "$metadata" == *" restore_hex="* ]]; then
+        local restore_hex="${metadata#* restore_hex=}"
+        metadata="${metadata%% restore_hex=*}"
+        _zacrs_decode_hex_to_REPLY "$restore_hex"
+        restore_text="$REPLY"
+    elif [[ "$metadata" == *" restore="* ]]; then
+        restore_text="${metadata#* restore=}"
+        metadata="${metadata%% restore=*}"
+    fi
+
+    local token
+    for token in ${(s: :)metadata}; do
+        [[ "$token" == "chain=1" ]] && chain=1
+        [[ "$token" == "execute=1" ]] && execute=1
+        [[ "$token" == cursor_offset=<-> ]] && cursor_offset="${token#cursor_offset=}"
+        if [[ "$token" == text_hex=* ]]; then
+            _zacrs_decode_hex_to_REPLY "${token#text_hex=}"
+            result_text="$REPLY"
+        fi
+    done
+}

--- a/shell/tests/protocol.zsh
+++ b/shell/tests/protocol.zsh
@@ -1,0 +1,39 @@
+#!/usr/bin/env zsh
+
+setopt errexit nounset pipefail
+
+typeset -r test_dir=${0:A:h}
+source "${test_dir:h}/_zacrs_protocol.zsh"
+
+typeset -i failures=0
+
+assert_equal() {
+    local expected="$1" actual="$2" description="$3"
+    if [[ "$actual" != "$expected" ]]; then
+        print -u2 -r -- "not ok: ${description} (expected=${(qqq)expected}, actual=${(qqq)actual})"
+        (( ++failures ))
+    else
+        print -r -- "ok: ${description}"
+    fi
+}
+
+result_text="legacy"
+chain=0
+execute=0
+restore_text=""
+cursor_offset=""
+_zacrs_parse_apply_line \
+    "APPLY chain=1 execute=0 cursor_offset=3 text_hex=666f6f0a62617220 restore_hex=62617a0a"
+
+assert_equal $'foo\nbar ' "$result_text" 'text hex preserves newline and trailing space'
+assert_equal $'baz\n' "$restore_text" 'restore hex preserves trailing newline'
+assert_equal 1 "$chain" 'chain flag is parsed'
+assert_equal 0 "$execute" 'execute flag is parsed'
+assert_equal 3 "$cursor_offset" 'cursor offset is parsed'
+
+result_text="legacy result"
+_zacrs_parse_apply_line "APPLY chain=0 execute=1 restore=legacy restore"
+assert_equal "legacy result" "$result_text" 'legacy result text remains unchanged'
+assert_equal "legacy restore" "$restore_text" 'legacy restore field is parsed'
+
+(( failures == 0 ))

--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -167,7 +167,7 @@ _zacrs_parse_render_header() {
 }
 
 # Connect to daemon, send a render request, and parse the response header.
-# Args: $1=cursor_row $2=cursor_col $3=prefix $4=candidates $5=selected (optional) $6=context_key (optional)
+# Args: $1=cursor_row $2=cursor_col $3=prefix $4=candidates $5=selected (optional) $6=context_key (optional) $7=command-position (0|1)
 # When $4 (candidates) is empty and $6 (context_key) is non-empty the request is
 # a cache-only attempt: no TSV is sent and the daemon resolves from its own cache.
 # On OK        (return 0): _zacrs_send_render_fd holds open fd; caller must sysread + close.
@@ -175,7 +175,7 @@ _zacrs_parse_render_header() {
 # On CACHE_MISS (return 3): fd already closed; caller should collect candidates and retry.
 # On ERROR/connect failure (return 2): fd already closed, daemon marked unavailable.
 _zacrs_daemon_send_render() {
-    local _cr="$1" _cc="$2" _pfx="$3" _cands="$4" _sel="${5:-}" _ctx_key="${6:-}"
+    local _cr="$1" _cc="$2" _pfx="$3" _cands="$4" _sel="${5:-}" _ctx_key="${6:-}" _cmd_pos="${7:-0}"
     local fd
     if ! zsocket "$_zacrs_socket_path" 2>/dev/null; then
         (( ${+functions[_zacrs_mark_daemon_unavailable]} )) && _zacrs_mark_daemon_unavailable
@@ -184,6 +184,7 @@ _zacrs_daemon_send_render() {
     fd=$REPLY
     local render_cmd="render $_cr $_cc $COLUMNS $LINES"
     [[ -n "$_ctx_key" ]] && render_cmd+=" context_key=$_ctx_key"
+    (( _cmd_pos )) && render_cmd+=" command_position=1"
     render_cmd+=" popup_key=$$"
     [[ -n "$_sel" ]] && render_cmd+=" selected=$_sel"
     print -u $fd -- "$render_cmd"
@@ -259,6 +260,8 @@ _zacrs_daemon_draw_atomic() {
 _zacrs_render() {
     local prefix="$1" prefix_len="$2" candidates_str="$3" from_gather="${4:-0}" selected="${5:-}" context_key="${6:-}"
     local cursor_row=0 cursor_col=0
+    local is_cmd_pos=0
+    _zacrs_is_cmd_pos "$LBUFFER" "$prefix" && is_cmd_pos=1
     # When the popup is already on screen and the terminal hasn't resized,
     # reuse the previous cursor position instead of querying the terminal.
     # This eliminates the \e[6n round-trip (an extra /dev/tty write + read
@@ -281,7 +284,7 @@ _zacrs_render() {
     # Try zsocket daemon path (no subprocess spawn)
     if (( _zacrs_daemon_available )); then
         local _prev_vis=$_zacrs_popup_visible _prev_row=$_zacrs_popup_row _prev_height=$_zacrs_popup_height
-        _zacrs_daemon_send_render "$cursor_row" "$cursor_col" "$prefix" "$candidates_str" "$selected" "$context_key"
+        _zacrs_daemon_send_render "$cursor_row" "$cursor_col" "$prefix" "$candidates_str" "$selected" "$context_key" "$is_cmd_pos"
         local _send_rc=$?
         if (( _send_rc == 0 )); then
             local fd=$_zacrs_send_render_fd
@@ -312,6 +315,7 @@ _zacrs_render() {
     _zacrs_clear_popup
     local -a render_args
     render_args=(render --prefix "$prefix" --cursor-row "$cursor_row" --cursor-col "$cursor_col")
+    (( is_cmd_pos )) && render_args+=(--command-position)
     [[ -n "$selected" ]] && render_args+=(--selected "$selected")
     local output
     output=$(printf '%s' "$candidates_str" | "$ZACRS_BIN" "${render_args[@]}")
@@ -379,9 +383,11 @@ _zacrs_parse_apply_line() {
     fi
 
     local token
+    cursor_offset=""
     for token in ${(s: :)metadata}; do
         [[ "$token" == "chain=1" ]] && chain=1
         [[ "$token" == "execute=1" ]] && execute=1
+        [[ "$token" == cursor_offset=<-> ]] && cursor_offset="${token#cursor_offset=}"
     done
 }
 
@@ -437,7 +443,11 @@ _zacrs_apply() {
     esac
 
     BUFFER="${new_lbuffer}${RBUFFER}"
-    CURSOR=${#new_lbuffer}
+    if [[ -n "$cursor_offset" && "$cursor_offset" == <-> ]]; then
+        CURSOR=$((${#base} + cursor_offset))
+    else
+        CURSOR=${#new_lbuffer}
+    fi
 
     if (( execute )) && [[ $result_code -eq 0 ]]; then
         _zacrs_prev_lbuffer="$new_lbuffer"
@@ -512,7 +522,7 @@ _zacrs_invoke_daemon() {
         return 1
     fi
 
-    local result_code result_text chain=0 execute=0 restore_text=""
+    local result_code result_text chain=0 execute=0 restore_text="" cursor_offset=""
     result_code="${${(s: :)lines[1]}[2]}"
     result_text="${lines[1]#DONE [0-9]## }"
     [[ "$result_text" == "${lines[1]}" ]] && result_text=""
@@ -574,7 +584,7 @@ _zacrs_invoke() {
         return 1
     fi
 
-    local result_code result_text chain=0 execute=0 restore_text=""
+    local result_code result_text chain=0 execute=0 restore_text="" cursor_offset=""
     result_code="${${(s: :)lines[1]}[2]}"
     result_text="${lines[1]#DONE [0-9]## }"
     [[ "$result_text" == "${lines[1]}" ]] && result_text=""
@@ -992,7 +1002,9 @@ TRAPWINCH() {
     if (( _zacrs_popup_visible && _zacrs_daemon_available )) \
         && [[ "$_zacrs_popup_snapshot_lbuffer" == "$LBUFFER" ]] \
         && (( _zacrs_popup_snapshot_columns == COLUMNS )); then
-        _zacrs_daemon_send_render "$_zacrs_popup_cursor_row" "$_zacrs_last_render_cursor_col" "" "" "" ""
+        local _resize_prefix="${LBUFFER##* }" _resize_cmd_pos=0
+        _zacrs_is_cmd_pos "$LBUFFER" "$_resize_prefix" && _resize_cmd_pos=1
+        _zacrs_daemon_send_render "$_zacrs_popup_cursor_row" "$_zacrs_last_render_cursor_col" "" "" "" "" "$_resize_cmd_pos"
         if (( $? == 0 )); then
             local fd=$_zacrs_send_render_fd
             local tty_len=$_zacrs_parsed_tty_len

--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -11,6 +11,7 @@ _zacrs_dir="${0:A:h}"
 source "${_zacrs_dir}/_zacrs_util.zsh"
 source "${_zacrs_dir}/_zacrs_gather.zsh"
 source "${_zacrs_dir}/_zacrs_compsys.zsh"
+source "${_zacrs_dir}/_zacrs_protocol.zsh"
 
 # Internal state
 typeset -g _zacrs_prev_lbuffer=""
@@ -353,43 +354,6 @@ _zacrs_clear_popup() {
 }
 
 # === Apply completion result to LBUFFER ===
-
-_zacrs_decode_hex_to_REPLY() {
-    local hex="$1"
-    REPLY=""
-    [[ -z "$hex" ]] && return 0
-
-    local i
-    for (( i = 1; i <= ${#hex}; i += 2 )); do
-        REPLY+=$(printf '%b' "\\x${hex[i,i+1]}")
-    done
-}
-
-_zacrs_parse_apply_line() {
-    local apply_line="$1"
-    local metadata="$apply_line"
-    chain=0
-    execute=0
-    restore_text=""
-
-    if [[ "$metadata" == *" restore_hex="* ]]; then
-        local restore_hex="${metadata#* restore_hex=}"
-        metadata="${metadata%% restore_hex=*}"
-        _zacrs_decode_hex_to_REPLY "$restore_hex"
-        restore_text="$REPLY"
-    elif [[ "$metadata" == *" restore="* ]]; then
-        restore_text="${metadata#* restore=}"
-        metadata="${metadata%% restore=*}"
-    fi
-
-    local token
-    cursor_offset=""
-    for token in ${(s: :)metadata}; do
-        [[ "$token" == "chain=1" ]] && chain=1
-        [[ "$token" == "execute=1" ]] && execute=1
-        [[ "$token" == cursor_offset=<-> ]] && cursor_offset="${token#cursor_offset=}"
-    done
-}
 
 _zacrs_read_done_response() {
     local fd="$1" header="$2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -363,6 +363,8 @@ mod tests {
                 text: s.to_string(),
                 description: String::new(),
                 kind: String::new(),
+                insert_text: None,
+                cursor_offset: None,
             })
             .collect()
     }

--- a/src/candidate.rs
+++ b/src/candidate.rs
@@ -30,6 +30,10 @@ impl Candidate {
         self.kind.ends_with("_rescue")
     }
 
+    pub fn is_user_defined(&self) -> bool {
+        self.base_kind() == "abbreviation"
+    }
+
     pub fn text_with_suffix(&self, suffixes: &SuffixConfig) -> String {
         let Some(suffix) = suffixes.suffix_for_kind(self.base_kind()) else {
             return self.text.clone();

--- a/src/candidate.rs
+++ b/src/candidate.rs
@@ -5,6 +5,8 @@ pub struct Candidate {
     pub text: String,
     pub description: String,
     pub kind: String,
+    pub insert_text: Option<String>,
+    pub cursor_offset: Option<usize>,
 }
 
 impl Candidate {
@@ -52,6 +54,9 @@ impl Candidate {
         suffixes: &SuffixConfig,
         is_command_position: bool,
     ) -> String {
+        if let Some(insert_text) = &self.insert_text {
+            return insert_text.clone();
+        }
         if is_command_position
             && self.kind.is_empty()
             && !self.text.ends_with('/')
@@ -89,6 +94,35 @@ impl Candidate {
             text,
             description,
             kind,
+            insert_text: None,
+            cursor_offset: None,
+        }
+    }
+
+    pub fn abbreviation(trigger: String, expansion: String, description: String) -> Self {
+        const CURSOR_MARKER: &str = "{{cursor}}";
+        let (insert_text, cursor_offset) = match expansion.find(CURSOR_MARKER) {
+            Some(offset) => (
+                expansion.replacen(CURSOR_MARKER, "", 1),
+                Some(expansion[..offset].chars().count()),
+            ),
+            None => (expansion, None),
+        };
+        let expansion_preview = insert_text
+            .replace('\r', "\\r")
+            .replace('\n', "\\n")
+            .replace('\t', "\\t");
+        let description = if description.is_empty() {
+            expansion_preview
+        } else {
+            format!("{expansion_preview} — {description}")
+        };
+        Self {
+            text: trigger,
+            description,
+            kind: "abbreviation".to_string(),
+            insert_text: Some(insert_text),
+            cursor_offset,
         }
     }
 }
@@ -127,6 +161,41 @@ mod tests {
         assert_eq!(c.text, "src/");
         assert_eq!(c.description, "directory");
         assert_eq!(c.kind, "directory");
+    }
+
+    #[test]
+    fn abbreviation_separates_trigger_from_insert_text() {
+        let c = Candidate::abbreviation(
+            "gcm".to_string(),
+            "git commit -m '{{cursor}}'".to_string(),
+            "commit with a message".to_string(),
+        );
+        assert_eq!(c.text, "gcm");
+        assert_eq!(c.insert_text.as_deref(), Some("git commit -m ''"));
+        assert_eq!(c.cursor_offset, Some(15));
+        assert_eq!(c.description, "git commit -m '' — commit with a message");
+        assert_eq!(c.kind, "abbreviation");
+    }
+
+    #[test]
+    fn abbreviation_uses_expansion_as_description_when_label_is_absent() {
+        let c = Candidate::abbreviation("gs".into(), "git status".into(), String::new());
+        assert_eq!(c.description, "git status");
+    }
+
+    #[test]
+    fn abbreviation_escapes_control_whitespace_in_description() {
+        let c = Candidate::abbreviation("multi".into(), "printf 'a\tb\n'".into(), String::new());
+        assert_eq!(c.description, "printf 'a\\tb\\n'");
+    }
+
+    #[test]
+    fn abbreviation_dismiss_with_space_expands_and_appends_space() {
+        let c = Candidate::abbreviation("gs".into(), "git status".into(), String::new());
+        assert_eq!(
+            c.text_for_dismiss_with_space(&SuffixConfig::default(), true),
+            "git status "
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,9 @@ pub enum Command {
         #[arg(long, default_value_t = 0)]
         cursor_col: u16,
 
+        #[arg(long, default_value_t = false)]
+        command_position: bool,
+
         /// Pre-select the N-th filtered candidate (0-indexed)
         #[arg(long)]
         selected: Option<usize>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,6 +27,7 @@ pub fn try_daemon_render(
     cursor_row: u16,
     cursor_col: u16,
     selected: Option<usize>,
+    command_position: bool,
     candidates_raw: &[u8],
 ) -> Result<RenderResponse, DaemonUnavailable> {
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((80, 24));
@@ -39,6 +40,7 @@ pub fn try_daemon_render(
         term_rows,
         candidates_tsv: candidates_raw.to_vec(),
         selected: selected.and_then(|s| u16::try_from(s).ok()),
+        command_position,
     };
 
     let response = send_request(&request)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crossterm::style::Color;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
 
@@ -15,6 +15,7 @@ pub struct Config {
     pub auto_insert_unambiguous: bool,
     pub suffixes: SuffixConfig,
     pub keybindings: KeybindingsRaw,
+    pub abbreviations: Vec<Abbreviation>,
     theme_raw: ThemeRaw,
 }
 
@@ -25,6 +26,7 @@ impl Default for Config {
             auto_insert_unambiguous: true,
             suffixes: SuffixConfig::default(),
             keybindings: KeybindingsRaw::default(),
+            abbreviations: Vec::new(),
             theme_raw: ThemeRaw::default(),
         }
     }
@@ -59,6 +61,31 @@ struct ConfigFile {
     completion: CompletionRaw,
     #[serde(default)]
     suffix: SuffixRaw,
+    #[serde(default)]
+    abbreviations: HashMap<String, String>,
+    #[serde(default, rename = "abbreviation")]
+    abbreviation: Vec<AbbreviationRaw>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Abbreviation {
+    pub trigger: String,
+    pub expansion: String,
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AbbreviationRaw {
+    trigger: String,
+    expansion: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default = "default_abbreviation_scope")]
+    scope: String,
+}
+
+fn default_abbreviation_scope() -> String {
+    "command".to_string()
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -222,6 +249,34 @@ impl Default for Theme {
 }
 
 impl Config {
+    fn abbreviations_from_file(file: &ConfigFile) -> Vec<Abbreviation> {
+        let mut by_trigger: BTreeMap<_, _> = file
+            .abbreviations
+            .iter()
+            .map(|(trigger, expansion)| Abbreviation {
+                trigger: trigger.clone(),
+                expansion: expansion.clone(),
+                description: String::new(),
+            })
+            .map(|abbr| (abbr.trigger.clone(), abbr))
+            .collect();
+        for abbr in file
+            .abbreviation
+            .iter()
+            .filter(|abbr| abbr.scope == "command")
+        {
+            by_trigger.insert(
+                abbr.trigger.clone(),
+                Abbreviation {
+                    trigger: abbr.trigger.clone(),
+                    expansion: abbr.expansion.clone(),
+                    description: abbr.description.clone(),
+                },
+            );
+        }
+        by_trigger.into_values().collect()
+    }
+
     pub fn load() -> Self {
         let Some(path) = config_path() else {
             return Config::default();
@@ -230,11 +285,13 @@ impl Config {
             return Config::default();
         };
         let file: ConfigFile = toml::from_str(&content).unwrap_or_default();
+        let abbreviations = Self::abbreviations_from_file(&file);
         Config {
             max_visible: 10,
             auto_insert_unambiguous: file.completion.auto_insert_unambiguous,
             suffixes: SuffixConfig::from_raw(file.suffix),
             keybindings: file.keybindings,
+            abbreviations,
             theme_raw: file.theme,
         }
     }
@@ -494,6 +551,39 @@ mod tests {
         assert!(
             file.completion.auto_insert_unambiguous,
             "fallback default must be true"
+        );
+    }
+
+    #[test]
+    fn abbreviations_parse_shorthand_and_detailed_forms() {
+        let file: ConfigFile = toml::from_str(
+            r#"
+[abbreviations]
+gs = "git status"
+
+[[abbreviation]]
+trigger = "gcm"
+expansion = "git commit -m '{{cursor}}'"
+description = "commit with a message"
+scope = "command"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            Config::abbreviations_from_file(&file),
+            vec![
+                Abbreviation {
+                    trigger: "gcm".into(),
+                    expansion: "git commit -m '{{cursor}}'".into(),
+                    description: "commit with a message".into(),
+                },
+                Abbreviation {
+                    trigger: "gs".into(),
+                    expansion: "git status".into(),
+                    description: String::new(),
+                },
+            ]
         );
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -29,6 +29,7 @@ struct ApplyResult {
     chain: bool,
     execute: bool,
     restore_text: String,
+    cursor_offset: Option<usize>,
 }
 
 impl ApplyResult {
@@ -39,6 +40,7 @@ impl ApplyResult {
             code: 0,
             execute: false,
             restore_text: String::new(),
+            cursor_offset: None,
         }
     }
 
@@ -49,6 +51,7 @@ impl ApplyResult {
             code: 0,
             execute: true,
             restore_text: String::new(),
+            cursor_offset: None,
         }
     }
 
@@ -59,6 +62,7 @@ impl ApplyResult {
             chain: false,
             execute: false,
             restore_text: String::new(),
+            cursor_offset: None,
         }
     }
 
@@ -69,6 +73,7 @@ impl ApplyResult {
             code: 2,
             execute: false,
             restore_text: String::new(),
+            cursor_offset: None,
         }
     }
 }
@@ -94,6 +99,7 @@ fn write_apply_result<W: Write>(writer: &mut W, result: &ApplyResult) -> io::Res
         chain: result.chain,
         execute: result.execute,
         restore_text: result.restore_text.clone(),
+        cursor_offset: result.cursor_offset,
     }
     .write_to(writer)
 }
@@ -105,6 +111,7 @@ struct RenderParams {
     term_cols: u16,
     term_rows: u16,
     selected: Option<usize>,
+    command_position: bool,
 }
 
 struct CompleteParams {
@@ -426,6 +433,7 @@ impl DaemonServer {
                 term_rows,
                 candidates_tsv,
                 selected,
+                command_position,
             } => {
                 let _span = info_span!(
                     "render",
@@ -447,6 +455,7 @@ impl DaemonServer {
                         term_cols,
                         term_rows,
                         selected: selected.map(usize::from),
+                        command_position,
                     },
                     &candidates_tsv,
                 );
@@ -563,6 +572,7 @@ impl DaemonServer {
                 selected,
                 context_key,
                 popup_key,
+                command_position,
             }) => {
                 let (mut prefix, tsv_opt) =
                     match read_prefix_and_candidates(reader, &mut writer, "render") {
@@ -603,6 +613,7 @@ impl DaemonServer {
                                 term_cols,
                                 term_rows,
                                 selected,
+                                command_position,
                             },
                             cached_tsv.as_bytes(),
                         );
@@ -650,6 +661,7 @@ impl DaemonServer {
                                     term_cols,
                                     term_rows,
                                     selected,
+                                    command_position,
                                 },
                                 cached_tsv.as_bytes(),
                             );
@@ -717,6 +729,7 @@ impl DaemonServer {
                         term_cols,
                         term_rows,
                         selected,
+                        command_position,
                     },
                     tsv.as_bytes(),
                 );
@@ -945,6 +958,7 @@ impl DaemonServer {
             term_cols,
             term_rows,
             selected,
+            command_position,
         } = params;
         let tsv_str = match std::str::from_utf8(candidates_tsv) {
             Ok(s) => s,
@@ -954,11 +968,21 @@ impl DaemonServer {
             }
         };
 
-        let candidates: Vec<Candidate> = tsv_str
+        let mut candidates: Vec<Candidate> = tsv_str
             .lines()
             .filter(|line| !line.is_empty())
             .map(Candidate::parse_line)
             .collect();
+
+        if command_position {
+            candidates.extend(self.config.abbreviations.iter().map(|abbr| {
+                Candidate::abbreviation(
+                    abbr.trigger.clone(),
+                    abbr.expansion.clone(),
+                    abbr.description.clone(),
+                )
+            }));
+        }
 
         if candidates.is_empty() {
             debug!("render request had no candidates");
@@ -1053,12 +1077,23 @@ impl DaemonServer {
         term_cols: u16,
         term_rows: u16,
         tsv: &str,
+        command_position: bool,
     ) -> Option<(App, Vec<u8>)> {
-        let candidates: Vec<Candidate> = tsv
+        let mut candidates: Vec<Candidate> = tsv
             .lines()
             .filter(|line| !line.is_empty())
             .map(Candidate::parse_line)
             .collect();
+
+        if command_position {
+            candidates.extend(self.config.abbreviations.iter().map(|abbr| {
+                Candidate::abbreviation(
+                    abbr.trigger.clone(),
+                    abbr.expansion.clone(),
+                    abbr.description.clone(),
+                )
+            }));
+        }
 
         if candidates.is_empty() {
             let _ = write_apply_result(writer, &ApplyResult::cancel(String::new()));
@@ -1116,7 +1151,14 @@ impl DaemonServer {
         } = params;
 
         let (mut app, scroll_bytes) = match self.setup_session(
-            writer, prefix, cursor_row, cursor_col, term_cols, term_rows, tsv,
+            writer,
+            prefix,
+            cursor_row,
+            cursor_col,
+            term_cols,
+            term_rows,
+            tsv,
+            command_position,
         ) {
             Some(v) => v,
             None => return,
@@ -1132,10 +1174,13 @@ impl DaemonServer {
             if let Some(candidate) = app.selected_candidate() {
                 let _ = write_apply_result(
                     writer,
-                    &ApplyResult::apply_only(candidate.text_with_suffix_for_command_position(
-                        &self.config.suffixes,
-                        command_position,
-                    )),
+                    &ApplyResult {
+                        cursor_offset: candidate.cursor_offset,
+                        ..ApplyResult::apply_only(candidate.text_with_suffix_for_command_position(
+                            &self.config.suffixes,
+                            command_position,
+                        ))
+                    },
                 );
             } else {
                 let _ = write_apply_result(writer, &ApplyResult::cancel(String::new()));
@@ -1188,6 +1233,7 @@ impl DaemonServer {
                                 chain: false,
                                 execute: false,
                                 restore_text: app.filter_text.clone(),
+                                cursor_offset: None,
                             },
                         );
                         break;
@@ -1259,12 +1305,15 @@ impl DaemonServer {
                                 Some(c) => {
                                     let _ = write_apply_result(
                                         writer,
-                                        &ApplyResult::confirm(
-                                            c.text_with_suffix_for_command_position(
-                                                &self.config.suffixes,
-                                                command_position,
-                                            ),
-                                        ),
+                                        &ApplyResult {
+                                            cursor_offset: c.cursor_offset,
+                                            ..ApplyResult::confirm(
+                                                c.text_with_suffix_for_command_position(
+                                                    &self.config.suffixes,
+                                                    command_position,
+                                                ),
+                                            )
+                                        },
                                     );
                                 }
                                 None => {
@@ -1324,6 +1373,7 @@ impl DaemonServer {
                                     chain: false,
                                     execute: false,
                                     restore_text: app.filter_text.clone(),
+                                    cursor_offset: None,
                                 },
                             );
                             break;
@@ -1824,6 +1874,7 @@ mod tests {
                 term_cols: 80,
                 term_rows: 24,
                 selected: None,
+                command_position: false,
             },
             b"git\tcommand\tcommand\ngrep\tcommand\tcommand\n",
         );
@@ -1846,6 +1897,7 @@ mod tests {
                 term_cols: 80,
                 term_rows: 24,
                 selected: None,
+                command_position: false,
             },
             b"git\tcommand\tcommand\n",
         );
@@ -1875,6 +1927,7 @@ mod tests {
                     term_cols: 80,
                     term_rows: 24,
                     selected: None,
+                    command_position: false,
                 },
                 b"git-log\tcommand\tcommand\ngit-status\tcommand\tcommand\n",
             );
@@ -1903,6 +1956,8 @@ mod tests {
                 text: "git-log".to_string(),
                 description: String::new(),
                 kind: "command".to_string(),
+                insert_text: None,
+                cursor_offset: None,
             }],
             "g".to_string(),
             5,
@@ -2453,6 +2508,76 @@ mod tests {
         assert_eq!(lines.next(), Some("DONE 0 cargo!"));
         assert_eq!(lines.next(), Some("APPLY chain=0 execute=0 restore_hex="));
         assert_eq!(lines.next(), None);
+    }
+
+    #[test]
+    fn handle_complete_confirm_expands_and_executes_command_abbreviation() {
+        let mut server = test_server();
+        server.config.abbreviations = vec![crate::config::Abbreviation {
+            trigger: "gcm".to_string(),
+            expansion: "git commit -m '{{cursor}}'".to_string(),
+            description: "commit with a message".to_string(),
+        }];
+
+        let mut reader = run_complete_session(
+            &mut server,
+            CompleteParams {
+                prefix: "gcm".to_string(),
+                cursor_row: 5,
+                cursor_col: 2,
+                term_cols: 80,
+                term_rows: 24,
+                prev_popup_row: None,
+                prev_popup_height: None,
+                command_position: true,
+                accept_single: false,
+                reuse_popup: false,
+                shift_tab_sequence: None,
+            },
+            "cargo\tcommand\tcommand\n",
+            &[SessionMessage::Key(b"\r")],
+        );
+
+        let _ = read_frame(&mut reader);
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).unwrap();
+        let result = read_text_complete_result(&bytes);
+        assert_eq!(result.text, "git commit -m ''");
+        assert_eq!(result.cursor_offset, Some(15));
+        assert!(result.execute);
+        assert!(!result.chain);
+    }
+
+    #[test]
+    fn handle_render_includes_abbreviation_at_command_position() {
+        let mut server = test_server();
+        server.config.abbreviations = vec![crate::config::Abbreviation {
+            trigger: "gs".to_string(),
+            expansion: "git status".to_string(),
+            description: "working tree status".to_string(),
+        }];
+
+        let response = server.handle_render(
+            RenderParams {
+                prefix: "gs".to_string(),
+                cursor_row: 5,
+                cursor_col: 2,
+                term_cols: 80,
+                term_rows: 24,
+                selected: None,
+                command_position: true,
+            },
+            b"cargo\tcommand\tcommand\n",
+        );
+
+        match response {
+            crate::protocol::Response::Success { tty_bytes, .. } => {
+                let rendered = String::from_utf8_lossy(&tty_bytes);
+                assert!(rendered.contains("gs"));
+                assert!(rendered.contains("git status"));
+            }
+            other => panic!("unexpected response: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1330,12 +1330,15 @@ impl DaemonServer {
                                 Some(c) => {
                                     let _ = write_apply_result(
                                         writer,
-                                        &ApplyResult::dismiss_with_space(
-                                            c.text_for_dismiss_with_space(
-                                                &self.config.suffixes,
-                                                command_position,
-                                            ),
-                                        ),
+                                        &ApplyResult {
+                                            cursor_offset: c.cursor_offset,
+                                            ..ApplyResult::dismiss_with_space(
+                                                c.text_for_dismiss_with_space(
+                                                    &self.config.suffixes,
+                                                    command_position,
+                                                ),
+                                            )
+                                        },
                                     );
                                 }
                                 None => {
@@ -1791,7 +1794,7 @@ mod tests {
         let mut reader = BufReader::new(Cursor::new(bytes));
         let mut done = String::new();
         reader.read_line(&mut done).unwrap();
-        TextCompleteResult::read_from(&mut reader, done.trim_end()).unwrap()
+        TextCompleteResult::read_from(&mut reader, done.trim_end_matches(['\r', '\n'])).unwrap()
     }
 
     fn test_server() -> DaemonServer {
@@ -2546,6 +2549,45 @@ mod tests {
         assert_eq!(result.cursor_offset, Some(15));
         assert!(result.execute);
         assert!(!result.chain);
+    }
+
+    #[test]
+    fn handle_complete_space_expands_abbreviation_and_preserves_cursor_offset() {
+        let mut server = test_server();
+        server.config.abbreviations = vec![crate::config::Abbreviation {
+            trigger: "gcm".to_string(),
+            expansion: "git commit -m '{{cursor}}'".to_string(),
+            description: "commit with a message".to_string(),
+        }];
+
+        let mut reader = run_complete_session(
+            &mut server,
+            CompleteParams {
+                prefix: "gcm".to_string(),
+                cursor_row: 5,
+                cursor_col: 2,
+                term_cols: 80,
+                term_rows: 24,
+                prev_popup_row: None,
+                prev_popup_height: None,
+                command_position: true,
+                accept_single: false,
+                reuse_popup: false,
+                shift_tab_sequence: None,
+            },
+            "cargo\tcommand\tcommand\n",
+            &[SessionMessage::Key(b" ")],
+        );
+
+        let _ = read_frame(&mut reader);
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).unwrap();
+        let result = read_text_complete_result(&bytes);
+        assert_eq!(result.code, 2);
+        assert_eq!(result.text, "git commit -m '' ");
+        assert_eq!(result.cursor_offset, Some(15));
+        assert!(!result.execute);
+        assert!(result.chain);
     }
 
     #[test]

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -335,8 +335,9 @@ fn case_sensitive_subsequence_matches(query: &str, haystack: &str) -> bool {
 }
 
 fn compare_empty_candidates(a: &Candidate, b: &Candidate) -> Ordering {
-    a.kind_priority()
-        .cmp(&b.kind_priority())
+    b.is_user_defined()
+        .cmp(&a.is_user_defined())
+        .then_with(|| a.kind_priority().cmp(&b.kind_priority()))
         .then_with(|| a.text.len().cmp(&b.text.len()))
         .then_with(|| a.text.cmp(&b.text))
 }
@@ -344,6 +345,7 @@ fn compare_empty_candidates(a: &Candidate, b: &Candidate) -> Ordering {
 fn compare_scored_candidates(a: &Candidate, a_score: u32, b: &Candidate, b_score: u32) -> Ordering {
     b_score
         .cmp(&a_score)
+        .then_with(|| b.is_user_defined().cmp(&a.is_user_defined()))
         .then_with(|| a.text.len().cmp(&b.text.len()))
         .then_with(|| a.kind_priority().cmp(&b.kind_priority()))
         .then_with(|| a.text.cmp(&b.text))
@@ -631,6 +633,32 @@ mod tests {
         let results = m.filter(&candidates, "gi");
         let texts: Vec<&str> = results.iter().map(|r| r.candidate.text.as_str()).collect();
         assert_eq!(texts[0], "git", "git should be first: {texts:?}");
+    }
+
+    #[test]
+    fn user_defined_abbreviation_wins_equal_scored_match() {
+        let mut m = FuzzyMatcher::new();
+        let candidates = vec![
+            Candidate::parse_line("gs\tcommand\tcommand"),
+            Candidate::abbreviation("gs".into(), "git status".into(), String::new()),
+        ];
+
+        let results = m.filter(&candidates, "gs");
+
+        assert_eq!(results[0].candidate.kind, "abbreviation");
+    }
+
+    #[test]
+    fn user_defined_abbreviations_lead_empty_query() {
+        let mut m = FuzzyMatcher::new();
+        let candidates = vec![
+            Candidate::parse_line("git\tcommand\tcommand"),
+            Candidate::abbreviation("gs".into(), "git status".into(), String::new()),
+        ];
+
+        let results = m.filter(&candidates, "");
+
+        assert_eq!(results[0].candidate.kind, "abbreviation");
     }
 
     #[test]

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -377,6 +377,8 @@ mod tests {
                 text: s.to_string(),
                 description: String::new(),
                 kind: String::new(),
+                insert_text: None,
+                cursor_offset: None,
             })
             .collect()
     }
@@ -601,6 +603,8 @@ mod tests {
                 text: text.to_string(),
                 description: String::new(),
                 kind: kind.to_string(),
+                insert_text: None,
+                cursor_offset: None,
             })
             .collect()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,8 +144,8 @@ fn run_render(
     cursor_row: u16,
     cursor_col: u16,
     selected: Option<usize>,
-    theme: &config::Theme,
-    auto_insert_unambiguous: bool,
+    command_position: bool,
+    config: &config::Config,
 ) -> io::Result<i32> {
     // Read raw stdin before trying daemon (we need it for both paths)
     let raw_stdin: Vec<u8> = {
@@ -155,9 +155,14 @@ fn run_render(
     };
 
     // Try daemon first
-    if let Ok(resp) =
-        client::try_daemon_render(&prefix, cursor_row, cursor_col, selected, &raw_stdin)
-    {
+    if let Ok(resp) = client::try_daemon_render(
+        &prefix,
+        cursor_row,
+        cursor_col,
+        selected,
+        command_position,
+        &raw_stdin,
+    ) {
         let mut tty = tty::open_tty_write()?;
         tty.write_all(&resp.tty_bytes)?;
         tty.flush()?;
@@ -168,12 +173,21 @@ fn run_render(
     }
 
     // Fallback: direct execution
-    let candidates: Vec<Candidate> = std::str::from_utf8(&raw_stdin)
+    let mut candidates: Vec<Candidate> = std::str::from_utf8(&raw_stdin)
         .unwrap_or("")
         .lines()
         .filter(|line| !line.is_empty())
         .map(Candidate::parse_line)
         .collect();
+    if command_position {
+        candidates.extend(config.abbreviations.iter().map(|abbr| {
+            Candidate::abbreviation(
+                abbr.trigger.clone(),
+                abbr.expansion.clone(),
+                abbr.description.clone(),
+            )
+        }));
+    }
 
     if candidates.is_empty() {
         return Ok(1);
@@ -184,7 +198,7 @@ fn run_render(
         return Ok(1);
     }
 
-    if !auto_insert_unambiguous {
+    if !config.auto_insert_unambiguous {
         app.reset_filter_to_prefix();
     }
 
@@ -199,7 +213,7 @@ fn run_render(
         app.set_selected(idx);
     }
 
-    ui::render::draw_popup_only(&mut tty, &app, theme)?;
+    ui::render::draw_popup_only(&mut tty, &app, &config.theme())?;
 
     let popup = ui::popup::Popup::compute(&app);
     let candidates_tsv = std::str::from_utf8(&raw_stdin).unwrap_or("");
@@ -287,17 +301,16 @@ fn main() {
             cursor_row,
             cursor_col,
             selected,
+            command_position,
         } => {
             let cfg = config::Config::load();
-            let auto_insert_unambiguous = cfg.auto_insert_unambiguous;
-            let theme = cfg.theme();
             match run_render(
                 prefix,
                 cursor_row,
                 cursor_col,
                 selected,
-                &theme,
-                auto_insert_unambiguous,
+                command_position,
+                &cfg,
             ) {
                 Ok(code) => process::exit(code),
                 Err(e) => {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -603,7 +603,12 @@ impl TextFrameHeader {
 
 impl TextCompleteResult {
     pub fn write_to(&self, mut writer: impl Write) -> io::Result<()> {
-        writeln!(writer, "DONE {} {}", self.code, self.text)?;
+        let encode_text = self.text.contains(['\r', '\n']);
+        if encode_text {
+            writeln!(writer, "DONE {}", self.code)?;
+        } else {
+            writeln!(writer, "DONE {} {}", self.code, self.text)?;
+        }
         write!(
             writer,
             "APPLY chain={} execute={}",
@@ -612,6 +617,13 @@ impl TextCompleteResult {
         )?;
         if let Some(cursor_offset) = self.cursor_offset {
             write!(writer, " cursor_offset={cursor_offset}")?;
+        }
+        if encode_text {
+            write!(
+                writer,
+                " text_hex={}",
+                encode_hex_bytes(self.text.as_bytes())
+            )?;
         }
         writeln!(
             writer,
@@ -634,7 +646,7 @@ impl TextCompleteResult {
             .next()
             .and_then(|value| value.parse().ok())
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing DONE code"))?;
-        let text = parts.next().unwrap_or_default().to_string();
+        let mut text = parts.next().unwrap_or_default().to_string();
 
         let mut apply = String::new();
         reader.read_line(&mut apply)?;
@@ -650,7 +662,7 @@ impl TextCompleteResult {
         let apply_fields = apply.strip_prefix("APPLY ").unwrap_or_default();
         let (flag_fields, restore_text) =
             if let Some((prefix, value)) = apply_fields.split_once(" restore_hex=") {
-                (prefix, decode_restore_text_hex(value)?)
+                (prefix, decode_text_hex(value, "restore_hex")?)
             } else if let Some((prefix, value)) = apply_fields.split_once(" restore=") {
                 (prefix, value.to_string())
             } else {
@@ -667,6 +679,8 @@ impl TextCompleteResult {
                 execute = value == "1";
             } else if let Some(value) = token.strip_prefix("cursor_offset=") {
                 cursor_offset = value.parse().ok();
+            } else if let Some(value) = token.strip_prefix("text_hex=") {
+                text = decode_text_hex(value, "text_hex")?;
             }
         }
 
@@ -681,15 +695,15 @@ impl TextCompleteResult {
     }
 }
 
-fn decode_restore_text_hex(hex: &str) -> io::Result<String> {
+fn decode_text_hex(hex: &str, field: &str) -> io::Result<String> {
     if hex.is_empty() {
         return Ok(String::new());
     }
 
     let bytes = decode_hex_bytes(hex)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid restore_hex"))?;
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, format!("invalid {field}")))?;
     String::from_utf8(bytes)
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid restore_hex utf-8"))
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, format!("invalid {field} utf-8")))
 }
 
 pub fn write_text_ok(writer: &mut impl Write, metadata: &str, tty_len: usize) -> io::Result<()> {
@@ -1059,6 +1073,33 @@ mod tests {
         let apply = format!("{}\n", lines.next().unwrap());
         let mut reader = io::BufReader::new(apply.as_bytes());
 
+        assert_eq!(
+            TextCompleteResult::read_from(&mut reader, done).unwrap(),
+            result
+        );
+    }
+
+    #[test]
+    fn text_complete_result_roundtrip_preserves_multiline_text() {
+        let result = TextCompleteResult {
+            code: 0,
+            text: "printf 'first\nsecond'\n".to_string(),
+            chain: false,
+            execute: true,
+            restore_text: String::new(),
+            cursor_offset: Some(7),
+        };
+
+        let mut buf = Vec::new();
+        result.write_to(&mut buf).unwrap();
+        let payload = String::from_utf8(buf).unwrap();
+        let mut lines = payload.lines();
+        let done = lines.next().unwrap();
+        let apply = format!("{}\n", lines.next().unwrap());
+        let mut reader = io::BufReader::new(apply.as_bytes());
+
+        assert_eq!(done, "DONE 0");
+        assert!(apply.contains(" text_hex="));
         assert_eq!(
             TextCompleteResult::read_from(&mut reader, done).unwrap(),
             result

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -25,6 +25,7 @@ pub enum Request {
         candidates_tsv: Vec<u8>,
         /// Pre-select the N-th filtered candidate before rendering.
         selected: Option<u16>,
+        command_position: bool,
     },
     Clear {
         popup_row: u16,
@@ -54,6 +55,7 @@ pub struct TextRenderRequest {
     pub selected: Option<usize>,
     pub context_key: Option<String>,
     pub popup_key: Option<String>,
+    pub command_position: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,6 +105,7 @@ pub struct TextCompleteResult {
     pub chain: bool,
     pub execute: bool,
     pub restore_text: String,
+    pub cursor_offset: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -168,6 +171,7 @@ impl Request {
                 term_rows,
                 candidates_tsv,
                 selected,
+                command_position,
             } => {
                 payload.push(CMD_RENDER);
                 let prefix_bytes = prefix.as_bytes();
@@ -178,7 +182,8 @@ impl Request {
                 write_u16(&mut payload, *term_cols);
                 write_u16(&mut payload, *term_rows);
                 // Flags byte: bit 0 = has_selected
-                let flags: u8 = if selected.is_some() { 0x01 } else { 0x00 };
+                let flags: u8 = if selected.is_some() { 0x01 } else { 0x00 }
+                    | if *command_position { 0x02 } else { 0x00 };
                 payload.push(flags);
                 if let Some(sel) = selected {
                     write_u16(&mut payload, *sel);
@@ -257,6 +262,7 @@ impl Request {
                 } else {
                     None
                 };
+                let command_position = flags & 0x02 != 0;
                 let candidates_tsv = cursor.to_vec();
                 Ok(Request::Render {
                     prefix,
@@ -266,6 +272,7 @@ impl Request {
                     term_rows,
                     candidates_tsv,
                     selected,
+                    command_position,
                 })
             }
             CMD_CLEAR => {
@@ -393,6 +400,7 @@ impl TextRequest {
                 let mut selected = None;
                 let mut context_key = None;
                 let mut popup_key = None;
+                let mut command_position = false;
                 for token in rest {
                     if let Some(value) = token.strip_prefix("selected=") {
                         selected = value.parse().ok();
@@ -400,6 +408,8 @@ impl TextRequest {
                         context_key = Some(value.to_string());
                     } else if let Some(value) = token.strip_prefix("popup_key=") {
                         popup_key = Some(value.to_string());
+                    } else if let Some(value) = token.strip_prefix("command_position=") {
+                        command_position = value == "1";
                     }
                 }
                 Some(Self::Render(TextRenderRequest {
@@ -410,6 +420,7 @@ impl TextRequest {
                     selected,
                     context_key,
                     popup_key,
+                    command_position,
                 }))
             }
             [
@@ -593,11 +604,18 @@ impl TextFrameHeader {
 impl TextCompleteResult {
     pub fn write_to(&self, mut writer: impl Write) -> io::Result<()> {
         writeln!(writer, "DONE {} {}", self.code, self.text)?;
-        writeln!(
+        write!(
             writer,
-            "APPLY chain={} execute={} restore_hex={}",
+            "APPLY chain={} execute={}",
             if self.chain { 1 } else { 0 },
             if self.execute { 1 } else { 0 },
+        )?;
+        if let Some(cursor_offset) = self.cursor_offset {
+            write!(writer, " cursor_offset={cursor_offset}")?;
+        }
+        writeln!(
+            writer,
+            " restore_hex={}",
             encode_hex_bytes(self.restore_text.as_bytes())
         )?;
         writer.flush()
@@ -641,11 +659,14 @@ impl TextCompleteResult {
 
         let mut chain = false;
         let mut execute = false;
+        let mut cursor_offset = None;
         for token in flag_fields.split_whitespace() {
             if let Some(value) = token.strip_prefix("chain=") {
                 chain = value == "1";
             } else if let Some(value) = token.strip_prefix("execute=") {
                 execute = value == "1";
+            } else if let Some(value) = token.strip_prefix("cursor_offset=") {
+                cursor_offset = value.parse().ok();
             }
         }
 
@@ -655,6 +676,7 @@ impl TextCompleteResult {
             chain,
             execute,
             restore_text,
+            cursor_offset,
         })
     }
 }
@@ -712,6 +734,7 @@ mod tests {
             term_rows: 24,
             candidates_tsv: b"git\tcommand\tcommand\ngrep\tcommand\tcommand\n".to_vec(),
             selected: None,
+            command_position: false,
         };
         let bytes = req.serialize();
         let parsed = Request::deserialize(&mut &bytes[..]).unwrap();
@@ -724,6 +747,7 @@ mod tests {
                 term_rows,
                 candidates_tsv,
                 selected,
+                command_position,
             } => {
                 assert_eq!(prefix, "gi");
                 assert_eq!(cursor_row, 5);
@@ -732,6 +756,7 @@ mod tests {
                 assert_eq!(term_rows, 24);
                 assert!(candidates_tsv.starts_with(b"git\t"));
                 assert_eq!(selected, None);
+                assert!(!command_position);
             }
             _ => panic!("expected Render"),
         }
@@ -747,6 +772,7 @@ mod tests {
             term_rows: 24,
             candidates_tsv: b"git\tcommand\tcommand\ngrep\tcommand\tcommand\n".to_vec(),
             selected: Some(1),
+            command_position: true,
         };
         let bytes = req.serialize();
         let parsed = Request::deserialize(&mut &bytes[..]).unwrap();
@@ -754,9 +780,11 @@ mod tests {
             Request::Render {
                 selected,
                 candidates_tsv,
+                command_position,
                 ..
             } => {
                 assert_eq!(selected, Some(1));
+                assert!(command_position);
                 assert!(candidates_tsv.starts_with(b"git\t"));
             }
             _ => panic!("expected Render"),
@@ -964,7 +992,7 @@ mod tests {
     #[test]
     fn text_render_request_header_parses_popup_key() {
         let parsed = TextRequest::parse_header(
-            "render 5 2 80 24 selected=1 context_key=ctx popup_key=popup",
+            "render 5 2 80 24 selected=1 context_key=ctx popup_key=popup command_position=1",
         )
         .unwrap();
         assert_eq!(
@@ -977,6 +1005,7 @@ mod tests {
                 selected: Some(1),
                 context_key: Some("ctx".to_string()),
                 popup_key: Some("popup".to_string()),
+                command_position: true,
             })
         );
     }
@@ -1019,6 +1048,7 @@ mod tests {
             chain: true,
             execute: false,
             restore_text: "cargo ".to_string(),
+            cursor_offset: None,
         };
 
         let mut buf = Vec::new();
@@ -1043,6 +1073,7 @@ mod tests {
             chain: false,
             execute: false,
             restore_text: "--foo=chain=1 execute=0".to_string(),
+            cursor_offset: None,
         };
 
         let mut buf = Vec::new();

--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -108,6 +108,8 @@ mod tests {
                 text: s.to_string(),
                 description: String::new(),
                 kind: String::new(),
+                insert_text: None,
+                cursor_offset: None,
             })
             .collect();
         App::new_with_term_size(

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -428,6 +428,8 @@ mod tests {
             text: "git".to_string(),
             description: String::new(),
             kind: String::new(),
+            insert_text: None,
+            cursor_offset: None,
         };
         let layout = layout_candidate(&c, 20);
         assert_eq!(layout.text, "git");
@@ -441,6 +443,8 @@ mod tests {
             text: "git".to_string(),
             description: "command".to_string(),
             kind: String::new(),
+            insert_text: None,
+            cursor_offset: None,
         };
         let layout = layout_candidate(&c, 20);
         assert_eq!(layout.text, "git");
@@ -457,11 +461,15 @@ mod tests {
                 text: "git".to_string(),
                 description: "command".to_string(),
                 kind: "command".to_string(),
+                insert_text: None,
+                cursor_offset: None,
             },
             Candidate {
                 text: "grep".to_string(),
                 description: "command".to_string(),
                 kind: "command".to_string(),
+                insert_text: None,
+                cursor_offset: None,
             },
         ];
         let app = App::new_with_term_size(candidates, "g".to_string(), 5, 2, 80, 24);
@@ -479,6 +487,8 @@ mod tests {
             text: "git".to_string(),
             description: String::new(),
             kind: String::new(),
+            insert_text: None,
+            cursor_offset: None,
         }];
         let app = App::new_with_term_size(candidates, "g".to_string(), 5, 2, 80, 24);
 
@@ -493,6 +503,8 @@ mod tests {
             text: "git".to_string(),
             description: String::new(),
             kind: String::new(),
+            insert_text: None,
+            cursor_offset: None,
         }];
         let app = App::new_with_term_size(candidates, "".to_string(), 4, 8, 0, 0);
 


### PR DESCRIPTION
## Summary

Add portable abbreviation expansion for issue #120.

- Define abbreviations with `[abbreviations]` or `[[abbreviation]]` in TOML
- Offer abbreviations only at command position
- Keep the displayed trigger separate from the inserted expansion
- Support explicit cursor placement with `{{cursor}}`
- Expand and execute on Enter, or expand and continue editing on Space
- Prefer user-defined abbreviations when completion scores are tied
- Keep daemon and subprocess behavior consistent

## Design boundaries

Abbreviations are loaded statically from configuration. Gathering and displaying candidates does not evaluate shell code, and abbreviation definitions do not install key bindings, widgets, hooks, aliases, functions, or traps.

Expansion results carry a shell-independent cursor offset through the protocol. Results containing line breaks are hex-encoded so they cannot corrupt the line-oriented protocol, while ordinary single-line results retain the existing format.

Configuration examples and behavior are documented in `docs/configuration.md`.

## Verification

- `CARGO_TARGET_DIR=target cargo test -q` (247 tests)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `zsh shell/tests/compsys_options.zsh`
- `zsh shell/tests/protocol.zsh`
- Zsh syntax checks for the plugin and test scripts
- Manual checks for automatic popup display, Tab, Enter, Space, and candidate ordering

### Abbreviation scaling benchmark

The benchmark injects abbreviations into 1,000 native candidates and includes candidate construction plus fuzzy filtering for the query `abbr`:

| Abbreviations | Median time |
| ---: | ---: |
| 0 | 30.7 µs |
| 100 | 89.0 µs |
| 1,000 | 402 µs |

Command: `CARGO_TARGET_DIR=target cargo bench --bench fuzzy_bench -- abbreviation_injection_and_filter --noplot`

Closes #120
