### PR TITLE
feat(shell): add zsh init command

### DIFF
--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -6,12 +6,15 @@
 
 ZACRS_BIN="${ZACRS_BIN:-zsh-autocomplete-rs}"
 
-# Source helpers
-_zacrs_dir="${0:A:h}"
-source "${_zacrs_dir}/_zacrs_util.zsh"
-source "${_zacrs_dir}/_zacrs_gather.zsh"
-source "${_zacrs_dir}/_zacrs_compsys.zsh"
-source "${_zacrs_dir}/_zacrs_protocol.zsh"
+# Source helpers for file-based installation. `init zsh` embeds them before this
+# file so startup does not need additional filesystem lookups.
+if (( ! ${+_zacrs_embedded_init} )); then
+    _zacrs_dir="${0:A:h}"
+    source "${_zacrs_dir}/_zacrs_util.zsh"
+    source "${_zacrs_dir}/_zacrs_gather.zsh"
+    source "${_zacrs_dir}/_zacrs_compsys.zsh"
+    source "${_zacrs_dir}/_zacrs_protocol.zsh"
+fi
 
 # Internal state
 typeset -g _zacrs_prev_lbuffer=""

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
 #[command(name = "zsh-autocomplete-rs")]
@@ -9,6 +9,11 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Command {
+    /// Print shell initialization code
+    Init {
+        #[arg(value_enum)]
+        shell: Shell,
+    },
     /// Popup session — Tab で起動
     Complete {
         #[arg(long, default_value = "", allow_hyphen_values = true)]
@@ -92,9 +97,21 @@ pub enum Command {
     },
 }
 
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum Shell {
+    Zsh,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn init_accepts_zsh() {
+        let cli = Cli::parse_from(["zsh-autocomplete-rs", "init", "zsh"]);
+
+        assert!(matches!(cli.command, Command::Init { shell: Shell::Zsh }));
+    }
 
     #[test]
     fn complete_accepts_shift_tab_hex() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use zsh_autocomplete_rs::app::App;
 use zsh_autocomplete_rs::candidate::Candidate;
-use zsh_autocomplete_rs::cli::{Cli, Command, DaemonAction};
+use zsh_autocomplete_rs::cli::{Cli, Command, DaemonAction, Shell};
 use zsh_autocomplete_rs::handoff::compute_reuse_token;
 use zsh_autocomplete_rs::protocol::TextCompleteResult;
 use zsh_autocomplete_rs::{client, config, daemon, protocol, tty, ui};
@@ -10,6 +10,32 @@ use std::io::{self, BufRead, BufWriter, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::process;
 use std::thread;
+
+const ZSH_INIT_PARTS: &[&[u8]] = &[
+    b"typeset -g _zacrs_embedded_init=1\n",
+    include_bytes!("../shell/_zacrs_util.zsh"),
+    include_bytes!("../shell/_zacrs_gather.zsh"),
+    include_bytes!("../shell/_zacrs_compsys.zsh"),
+    include_bytes!("../shell/_zacrs_protocol.zsh"),
+    include_bytes!("../shell/zsh-autocomplete-rs.plugin.zsh"),
+    b"unset _zacrs_embedded_init\n",
+];
+
+fn run_init(shell: Shell) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut writer = BufWriter::new(stdout.lock());
+    match shell {
+        Shell::Zsh => {
+            for part in ZSH_INIT_PARTS {
+                writer.write_all(part)?;
+                if !part.ends_with(b"\n") {
+                    writer.write_all(b"\n")?;
+                }
+            }
+        }
+    }
+    writer.flush()
+}
 
 fn trim_line_end(line: &str) -> &str {
     line.trim_end_matches(['\r', '\n'])
@@ -252,6 +278,13 @@ fn run_clear(popup_row: u16, popup_height: u16, cursor_row: u16) -> io::Result<i
 fn main() {
     let cli = Cli::parse();
     match cli.command {
+        Command::Init { shell } => match run_init(shell) {
+            Ok(()) => process::exit(0),
+            Err(e) => {
+                eprintln!("init error: {}", e);
+                process::exit(1);
+            }
+        },
         Command::Complete {
             prefix,
             cursor_row,


### PR DESCRIPTION
## Summary

- add `zsh-autocomplete-rs init zsh` for convenient shell setup
- embed the Zsh helpers and plugin in the binary at compile time
- preserve the existing file-based `source` installation path

## Why

Users can initialize the plugin with:

```zsh
eval "$(zsh-autocomplete-rs init zsh)"
```

The command writes pre-embedded static bytes, avoiding runtime script discovery and assembly. In a release build, the command itself averaged about 1.0 ms over 100 runs.

## Validation

- `CARGO_TARGET_DIR=target cargo test -q` (250 passed)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `zsh shell/tests/compsys_options.zsh`
- `zsh shell/tests/protocol.zsh`
- generated init output checked with `zsh -n`
- `git diff --check`
