### PR TITLE
fix(completion): keep inline abbreviations visible during typo rescue

### DIFF
--- a/shell/_zacrs_util.zsh
+++ b/shell/_zacrs_util.zsh
@@ -53,6 +53,13 @@ _zacrs_is_cmd_pos() {
     return 1
 }
 
+# Render command-position requests even when compsys produced no candidates.
+# The Rust side may still contribute configured abbreviations.
+# Args: $1=candidates $2=buffer $3=prefix
+_zacrs_should_render_candidates() {
+    [[ -n "$1" ]] || _zacrs_is_cmd_pos "$2" "$3"
+}
+
 # Infer the shell command kind for a bare command-position token.
 # Sets REPLY to one of: alias, builtin, function, command.
 _zacrs_command_kind() {

--- a/shell/tests/compsys_options.zsh
+++ b/shell/tests/compsys_options.zsh
@@ -3,6 +3,7 @@
 setopt errexit nounset pipefail
 
 typeset -r test_dir=${0:A:h}
+source "${test_dir:h}/_zacrs_util.zsh"
 source "${test_dir:h}/_zacrs_compsys.zsh"
 
 typeset -i failures=0
@@ -52,5 +53,21 @@ assert_path_kind directory "$test_dir" 'directory candidate keeps directory kind
 assert_path_kind file "$0" 'file candidate keeps file kind'
 HOME="$test_dir" assert_path_kind directory '~/' 'home-relative directory candidate keeps directory kind'
 HOME="$test_dir" assert_path_kind file '~/compsys_options.zsh' 'home-relative file candidate keeps file kind'
+
+assert_render_gate() {
+    local expected=$1 candidates=$2 buffer=$3 prefix=$4 description=$5
+    local actual=0
+    _zacrs_should_render_candidates "$candidates" "$buffer" "$prefix" && actual=1
+    if (( actual != expected )); then
+        print -u2 -r -- "not ok: ${description} (expected=${expected}, actual=${actual})"
+        (( ++failures ))
+    else
+        print -r -- "ok: ${description}"
+    fi
+}
+
+assert_render_gate 1 '' gpo gpo 'command position reaches configured abbreviations without shell candidates'
+assert_render_gate 0 '' 'git gpo' gpo 'argument position still skips an empty candidate request'
+assert_render_gate 1 $'git\tcommand\tcommand' 'git gpo' gpo 'shell candidates render in argument position'
 
 (( failures == 0 ))

--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -172,8 +172,8 @@ _zacrs_parse_render_header() {
 
 # Connect to daemon, send a render request, and parse the response header.
 # Args: $1=cursor_row $2=cursor_col $3=prefix $4=candidates $5=selected (optional) $6=context_key (optional) $7=command-position (0|1) $8=candidates-present (0|1)
-# When $4 (candidates) is empty and $6 (context_key) is non-empty the request is
-# a cache-only attempt: no TSV is sent and the daemon resolves from its own cache.
+# When candidates are empty, $8 distinguishes an explicit empty candidate set
+# from a cache-only request. Cache-first and resize callers leave $8 unset.
 # On OK        (return 0): _zacrs_send_render_fd holds open fd; caller must sysread + close.
 # On EMPTY     (return 1): fd already closed.
 # On CACHE_MISS (return 3): fd already closed; caller should collect candidates and retry.

--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -171,7 +171,7 @@ _zacrs_parse_render_header() {
 }
 
 # Connect to daemon, send a render request, and parse the response header.
-# Args: $1=cursor_row $2=cursor_col $3=prefix $4=candidates $5=selected (optional) $6=context_key (optional) $7=command-position (0|1)
+# Args: $1=cursor_row $2=cursor_col $3=prefix $4=candidates $5=selected (optional) $6=context_key (optional) $7=command-position (0|1) $8=candidates-present (0|1)
 # When $4 (candidates) is empty and $6 (context_key) is non-empty the request is
 # a cache-only attempt: no TSV is sent and the daemon resolves from its own cache.
 # On OK        (return 0): _zacrs_send_render_fd holds open fd; caller must sysread + close.
@@ -179,7 +179,7 @@ _zacrs_parse_render_header() {
 # On CACHE_MISS (return 3): fd already closed; caller should collect candidates and retry.
 # On ERROR/connect failure (return 2): fd already closed, daemon marked unavailable.
 _zacrs_daemon_send_render() {
-    local _cr="$1" _cc="$2" _pfx="$3" _cands="$4" _sel="${5:-}" _ctx_key="${6:-}" _cmd_pos="${7:-0}"
+    local _cr="$1" _cc="$2" _pfx="$3" _cands="$4" _sel="${5:-}" _ctx_key="${6:-}" _cmd_pos="${7:-0}" _cands_present="${8:-0}"
     local fd
     if ! zsocket "$_zacrs_socket_path" 2>/dev/null; then
         (( ${+functions[_zacrs_mark_daemon_unavailable]} )) && _zacrs_mark_daemon_unavailable
@@ -189,6 +189,7 @@ _zacrs_daemon_send_render() {
     local render_cmd="render $_cr $_cc $COLUMNS $LINES"
     [[ -n "$_ctx_key" ]] && render_cmd+=" context_key=$_ctx_key"
     (( _cmd_pos )) && render_cmd+=" command_position=1"
+    (( _cands_present )) && render_cmd+=" candidates_present=1"
     render_cmd+=" popup_key=$$"
     [[ -n "$_sel" ]] && render_cmd+=" selected=$_sel"
     print -u $fd -- "$render_cmd"
@@ -288,7 +289,7 @@ _zacrs_render() {
     # Try zsocket daemon path (no subprocess spawn)
     if (( _zacrs_daemon_available )); then
         local _prev_vis=$_zacrs_popup_visible _prev_row=$_zacrs_popup_row _prev_height=$_zacrs_popup_height
-        _zacrs_daemon_send_render "$cursor_row" "$cursor_col" "$prefix" "$candidates_str" "$selected" "$context_key" "$is_cmd_pos"
+        _zacrs_daemon_send_render "$cursor_row" "$cursor_col" "$prefix" "$candidates_str" "$selected" "$context_key" "$is_cmd_pos" 1
         local _send_rc=$?
         if (( _send_rc == 0 )); then
             local fd=$_zacrs_send_render_fd

--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -909,12 +909,16 @@ _zacrs_line_pre_redraw() {
     # Heavy path 完了後、デバウンスウィンドウを設定 (50ms)
     (( ${+EPOCHREALTIME} )) && _zacrs_debounce_until=$(( EPOCHREALTIME + 0.050 ))
 
-    [[ -z "$candidates_str" ]] && { _zacrs_clear_popup; return }
+    _zacrs_should_render_candidates "$candidates_str" "$LBUFFER" "$prefix" \
+        || { _zacrs_clear_popup; return }
 
     local -a cands
     cands=( ${(f)candidates_str} )
     cands=( ${cands:#} )
-    [[ ${#cands[@]} -eq 0 ]] && { _zacrs_clear_popup; return }
+    if [[ -n "$candidates_str" && ${#cands[@]} -eq 0 ]]; then
+        _zacrs_clear_popup
+        return
+    fi
 
     # Type-ahead arrived during candidate gathering: skip render.
     # Reset prev_lbuffer so the next redraw retries this buffer.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -573,6 +573,7 @@ impl DaemonServer {
                 context_key,
                 popup_key,
                 command_position,
+                candidates_present,
             }) => {
                 let (mut prefix, tsv_opt) =
                     match read_prefix_and_candidates(reader, &mut writer, "render") {
@@ -583,7 +584,7 @@ impl DaemonServer {
                 // A non-empty command-position prefix can be completed solely by
                 // configured abbreviations.  In that case the shell intentionally
                 // sends no TSV lines; do not mistake it for a popup-cache lookup.
-                if tsv_opt.is_none() && command_position && !prefix.is_empty() {
+                if tsv_opt.is_none() && candidates_present {
                     let response = self.handle_render(
                         RenderParams {
                             prefix: prefix.clone(),
@@ -2678,7 +2679,7 @@ mod tests {
         let output = run_text_request(
             &mut server,
             text_request_input(
-                "render 5 2 80 24 popup_key=popup-1 command_position=1",
+                "render 5 2 80 24 popup_key=popup-1 command_position=1 candidates_present=1",
                 "gpo",
                 None,
             ),
@@ -2966,7 +2967,7 @@ mod tests {
         let output = run_text_request(
             &mut server,
             text_request_input(
-                "render 5 2 80 24 context_key=ctx-1 popup_key=popup-1",
+                "render 5 2 80 24 context_key=ctx-1 popup_key=popup-1 command_position=1",
                 "st",
                 None,
             ),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -580,6 +580,45 @@ impl DaemonServer {
                         Err(()) => return false,
                     };
 
+                // A non-empty command-position prefix can be completed solely by
+                // configured abbreviations.  In that case the shell intentionally
+                // sends no TSV lines; do not mistake it for a popup-cache lookup.
+                if tsv_opt.is_none() && command_position && !prefix.is_empty() {
+                    let response = self.handle_render(
+                        RenderParams {
+                            prefix: prefix.clone(),
+                            cursor_row,
+                            cursor_col,
+                            term_cols,
+                            term_rows,
+                            selected,
+                            command_position,
+                        },
+                        b"",
+                    );
+                    match response {
+                        Response::Success {
+                            tty_bytes,
+                            metadata,
+                        } => {
+                            if let Some(ref key) = popup_key {
+                                self.store_active_popup(key, prefix, String::new());
+                            }
+                            let meta = metadata.unwrap_or_default();
+                            let _ = protocol::write_text_ok(&mut writer, &meta, tty_bytes.len());
+                            let _ = writer.write_all(&tty_bytes);
+                            let _ = writer.flush();
+                        }
+                        Response::Empty => {
+                            let _ = writeln!(writer, "EMPTY");
+                        }
+                        Response::Error(msg) => {
+                            let _ = writeln!(writer, "ERROR {}", msg);
+                        }
+                    }
+                    return false;
+                }
+
                 // Cache-only request: TSV absent, context_key present.
                 if tsv_opt.is_none() {
                     let active_popup = if context_key.is_none() {
@@ -2620,6 +2659,35 @@ mod tests {
             }
             other => panic!("unexpected response: {other:?}"),
         }
+    }
+
+    #[test]
+    fn handle_text_render_empty_tsv_includes_command_abbreviation() {
+        let mut server = test_server();
+        server.config.abbreviations = vec![crate::config::Abbreviation {
+            trigger: "gpo".to_string(),
+            expansion: "git push origin HEAD".to_string(),
+            description: String::new(),
+        }];
+        server.store_active_popup(
+            "popup-1",
+            "g".to_string(),
+            "go\tcommand\tcommand\n".to_string(),
+        );
+
+        let output = run_text_request(
+            &mut server,
+            text_request_input(
+                "render 5 2 80 24 popup_key=popup-1 command_position=1",
+                "gpo",
+                None,
+            ),
+        );
+
+        let (_, tty) = read_text_ok(&output);
+        assert!(tty.contains("gpo"), "tty was: {tty:?}");
+        assert!(tty.contains("git push origin HEAD"), "tty was: {tty:?}");
+        assert!(!tty.contains("go"), "tty was: {tty:?}");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -581,9 +581,9 @@ impl DaemonServer {
                         Err(()) => return false,
                     };
 
-                // A non-empty command-position prefix can be completed solely by
-                // configured abbreviations.  In that case the shell intentionally
-                // sends no TSV lines; do not mistake it for a popup-cache lookup.
+                // An explicit empty candidate set can still be completed from
+                // configured abbreviations. Do not conflate it with a cache-only
+                // request, which also has no TSV lines but leaves this flag unset.
                 if tsv_opt.is_none() && candidates_present {
                     let response = self.handle_render(
                         RenderParams {
@@ -1509,9 +1509,10 @@ fn drain_key_payload<R: std::io::Read>(reader: &mut R, byte_count: usize) -> io:
 
 /// Reads prefix line and optional TSV candidate payload from the text protocol stream.
 ///
-/// Returns `(prefix, None)` when `END` follows the prefix line directly
-/// (no TSV candidates), which signals a daemon cache lookup attempt.
-/// Returns `(prefix, Some(tsv))` when TSV candidates are present.
+/// Returns `(prefix, None)` when `END` follows the prefix line directly and
+/// `(prefix, Some(tsv))` when TSV candidates are present. The request header's
+/// `candidates_present` flag distinguishes an explicit empty candidate set from
+/// a cache-only request; this parser only reports the payload shape.
 fn read_prefix_and_candidates(
     reader: &mut impl BufRead,
     writer: &mut impl Write,

--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -212,11 +212,15 @@ fn should_match_candidate(
     max_typos: usize,
     smart_case: bool,
 ) -> bool {
-    if rescue_only
-        && (!candidate.is_typo_rescue()
-            || normalized_text.chars().count().abs_diff(query_len) > max_typos)
-    {
-        return false;
+    if rescue_only {
+        if candidate.is_user_defined() {
+            // User abbreviations remain eligible when command typo rescue is
+            // active; they are injected independently of the rescue source.
+        } else if !candidate.is_typo_rescue()
+            || normalized_text.chars().count().abs_diff(query_len) > max_typos
+        {
+            return false;
+        }
     }
 
     if smart_case && !case_sensitive_subsequence_matches(normalized_query, normalized_text) {
@@ -646,6 +650,21 @@ mod tests {
         let results = m.filter(&candidates, "gs");
 
         assert_eq!(results[0].candidate.kind, "abbreviation");
+    }
+
+    #[test]
+    fn user_defined_abbreviation_remains_visible_with_typo_rescue_candidates() {
+        let mut m = FuzzyMatcher::new();
+        let candidates = vec![
+            Candidate::parse_line("go\tcommand\tcommand_rescue"),
+            Candidate::parse_line("gpg\tcommand\tcommand_rescue"),
+            Candidate::abbreviation("gpo".into(), "git push origin HEAD".into(), String::new()),
+        ];
+
+        let results = m.filter(&candidates, "gpo");
+
+        assert_eq!(results[0].candidate.kind, "abbreviation");
+        assert_eq!(results[0].candidate.text, "gpo");
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -56,6 +56,7 @@ pub struct TextRenderRequest {
     pub context_key: Option<String>,
     pub popup_key: Option<String>,
     pub command_position: bool,
+    pub candidates_present: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -401,6 +402,7 @@ impl TextRequest {
                 let mut context_key = None;
                 let mut popup_key = None;
                 let mut command_position = false;
+                let mut candidates_present = false;
                 for token in rest {
                     if let Some(value) = token.strip_prefix("selected=") {
                         selected = value.parse().ok();
@@ -410,6 +412,8 @@ impl TextRequest {
                         popup_key = Some(value.to_string());
                     } else if let Some(value) = token.strip_prefix("command_position=") {
                         command_position = value == "1";
+                    } else if let Some(value) = token.strip_prefix("candidates_present=") {
+                        candidates_present = value == "1";
                     }
                 }
                 Some(Self::Render(TextRenderRequest {
@@ -421,6 +425,7 @@ impl TextRequest {
                     context_key,
                     popup_key,
                     command_position,
+                    candidates_present,
                 }))
             }
             [
@@ -1006,7 +1011,7 @@ mod tests {
     #[test]
     fn text_render_request_header_parses_popup_key() {
         let parsed = TextRequest::parse_header(
-            "render 5 2 80 24 selected=1 context_key=ctx popup_key=popup command_position=1",
+            "render 5 2 80 24 selected=1 context_key=ctx popup_key=popup command_position=1 candidates_present=1",
         )
         .unwrap();
         assert_eq!(
@@ -1020,6 +1025,7 @@ mod tests {
                 context_key: Some("ctx".to_string()),
                 popup_key: Some("popup".to_string()),
                 command_position: true,
+                candidates_present: true,
             })
         );
     }


### PR DESCRIPTION
## Summary

- keep configured abbreviations eligible when command typo-rescue candidates are active
- allow command-position abbreviation rendering when the shell contributes no candidates
- distinguish explicit empty candidate sets from cache-only text-protocol renders
- preserve context and popup cache reuse for command-position requests

## Root cause

For command prefixes of three or more characters, the typo-rescue filter only admitted candidates whose kind ended in `_rescue`. Configured abbreviations use the `abbreviation` kind, so an exact abbreviation such as `gpo` was removed even though it had been injected by the daemon.

The shell also stopped before invoking Rust when its own candidate set was empty. Supporting abbreviation-only renders exposed an ambiguity in the text protocol: both an explicit empty candidate set and a cache-only request had no TSV payload. The new `candidates_present=1` header flag makes that distinction explicit without bypassing daemon caches.

## User impact

Typing a configured abbreviation inline now shows it in the automatic popup, including when typo-rescue command candidates are present or the shell has no native candidates. Cache-first and resize rendering continue to reuse daemon candidates.

## Validation

- `CARGO_TARGET_DIR=target cargo test -q` (252 tests)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `zsh shell/tests/compsys_options.zsh`
- `zsh shell/tests/protocol.zsh`
- Zsh syntax checks for plugin and helper scripts
- manual verification with `gpo = 'git push origin HEAD'`
