### PR TITLE
fix(shell): avoid re-adding captured completion candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,4 +93,5 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zsh
       - run: cargo test
       - run: zsh shell/tests/compsys_options.zsh
+      - run: zsh shell/tests/compsys_state.zsh
       - run: zsh shell/tests/protocol.zsh

--- a/shell/_zacrs_compsys.zsh
+++ b/shell/_zacrs_compsys.zsh
@@ -156,9 +156,12 @@ _zacrs_compsys_func() {
             done
         else
             _zacrs_dbg "  compadd[$_zacrs_compadd_calls]: SKIPPED (-O/-D) args: ${(j: :)${(@q)@}}"
+            # Probe calls explicitly request their own output arrays and must
+            # retain the original compadd behavior. Regular calls are captured
+            # above only: zacrs renders its own popup and suppresses compsys'
+            # insertion and list output after completion returns.
+            builtin compadd "$@"
         fi
-
-        builtin compadd "$@"
     }
 
     # Call the completion system entry point

--- a/shell/_zacrs_compsys.zsh
+++ b/shell/_zacrs_compsys.zsh
@@ -192,9 +192,11 @@ _zacrs_compsys_func() {
             # candidate set in full. Native insertion/list output is suppressed
             # after _main_complete returns.
             if (( ${#_zacrs_cap} > 0 )); then
-                local -a _zacrs_state_matches=( "${_zacrs_cap[1,101]}" )
+                local -a _zacrs_state_matches=( "${(@)_zacrs_cap[1,101]}" )
                 builtin compadd -QU - "${_zacrs_state_matches[@]}"
+                return 0
             fi
+            return 1
         else
             _zacrs_dbg "  compadd[$_zacrs_compadd_calls]: SKIPPED (-O/-D) args: ${(j: :)${(@q)@}}"
             # Probe calls explicitly request their own output arrays and must

--- a/shell/_zacrs_compsys.zsh
+++ b/shell/_zacrs_compsys.zsh
@@ -60,6 +60,37 @@ _zacrs_compadd_has_file_flag() {
     return 1
 }
 
+_zacrs_compadd_has_array_output_flag() {
+    local _arg _chars _char
+    local -i _idx _expect_value=0
+
+    for _arg in "$@"; do
+        if (( _expect_value )); then
+            _expect_value=0
+            continue
+        fi
+        [[ "$_arg" == "-" || "$_arg" == "--" ]] && break
+        [[ "$_arg" == -?* ]] || continue
+
+        _chars="${_arg[2,-1]}"
+        for (( _idx = 1; _idx <= ${#_chars}; _idx++ )); do
+            _char="${_chars[_idx]}"
+            case "$_char" in
+                [OD]) return 0 ;;
+                [akqQenUfl12C]) ;;
+                [diIAVJXxPSpsWFMrRE])
+                    (( _idx == ${#_chars} )) && _expect_value=1
+                    break
+                    ;;
+                o) break ;;
+                *) break ;;
+            esac
+        done
+    done
+
+    return 1
+}
+
 _zacrs_path_candidate_kind() {
     local _path="$1"
     case "$_path" in
@@ -97,6 +128,7 @@ _zacrs_compsys_func() {
         local _a _skip=0 _xdesc="" _vis_prefix="" _vis_suffix="" _hidden_prefix="" _is_file=0 _disp_array_name=""
         local _prev="" _is_option_value=0 _prev_flags=""
         _zacrs_compadd_has_file_flag "$@" && _is_file=1
+        _zacrs_compadd_has_array_output_flag "$@" && _skip=1
         for _a in "$@"; do
             _is_option_value=0
             if (( ${#_prev} >= 2 )); then
@@ -110,7 +142,6 @@ _zacrs_compsys_func() {
             else
                 [[ "$_a" == "-" || "$_a" == "--" ]] && break
             fi
-            [[ "$_a" == "-O" || "$_a" == "-D" ]] && { _skip=1; break; }
             [[ "$_prev" == "-P" ]] && _vis_prefix="$_a"
             [[ "$_prev" == "-p" ]] && _hidden_prefix="$_a"
             [[ "$_prev" == "-S" ]] && _vis_suffix="$_a"
@@ -154,6 +185,16 @@ _zacrs_compsys_func() {
                 fi
                 _zacrs_captured+=( "${_text}"$'\t'"${_desc_map[$_m]:-$_xdesc}"$'\t'"${_kind}" )
             done
+
+            # Completion helpers use compstate[nmatches] to decide whether a
+            # source succeeded and whether to try alternatives. Preserve zero,
+            # single, and many-match behavior without re-adding a pathological
+            # candidate set in full. Native insertion/list output is suppressed
+            # after _main_complete returns.
+            if (( ${#_zacrs_cap} > 0 )); then
+                local -a _zacrs_state_matches=( "${_zacrs_cap[1,101]}" )
+                builtin compadd -QU - "${_zacrs_state_matches[@]}"
+            fi
         else
             _zacrs_dbg "  compadd[$_zacrs_compadd_calls]: SKIPPED (-O/-D) args: ${(j: :)${(@q)@}}"
             # Probe calls explicitly request their own output arrays and must

--- a/shell/_zacrs_compsys.zsh
+++ b/shell/_zacrs_compsys.zsh
@@ -76,9 +76,9 @@ _zacrs_compadd_has_array_output_flag() {
         for (( _idx = 1; _idx <= ${#_chars}; _idx++ )); do
             _char="${_chars[_idx]}"
             case "$_char" in
-                [OD]) return 0 ;;
+                [OAD]) return 0 ;;
                 [akqQenUfl12C]) ;;
-                [diIAVJXxPSpsWFMrRE])
+                [diIVJXxPSpsWFMrRE])
                     (( _idx == ${#_chars} )) && _expect_value=1
                     break
                     ;;

--- a/shell/tests/compsys_options.zsh
+++ b/shell/tests/compsys_options.zsh
@@ -38,6 +38,27 @@ assert_file_flag 0 'value after combined suffix option containing f' -Qs -foo ca
 assert_file_flag 0 'candidate after option terminator' - -foo
 assert_file_flag 0 'candidate after double option terminator' -- -foo
 
+assert_array_output_flag() {
+    local expected=$1 description=$2
+    shift 2
+
+    local actual=0
+    _zacrs_compadd_has_array_output_flag "$@" && actual=1
+    if (( actual != expected )); then
+        print -u2 -r -- "not ok: ${description} (expected=${expected}, actual=${actual})"
+        (( ++failures ))
+    else
+        print -r -- "ok: ${description}"
+    fi
+}
+
+assert_array_output_flag 1 'standalone capture output flag' -O matches candidate
+assert_array_output_flag 1 'combined capture output flag' -QO matches candidate
+assert_array_output_flag 1 'standalone display output flag' -D displays candidate
+assert_array_output_flag 1 'combined display output flag' -QD displays candidate
+assert_array_output_flag 0 'output flag after option terminator is a candidate' - -O
+assert_array_output_flag 0 'option value containing O is not an output flag' -P -Output candidate
+
 assert_path_kind() {
     local expected=$1 path=$2 description=$3
     _zacrs_path_candidate_kind "$path"

--- a/shell/tests/compsys_options.zsh
+++ b/shell/tests/compsys_options.zsh
@@ -56,8 +56,11 @@ assert_array_output_flag 1 'standalone capture output flag' -O matches candidate
 assert_array_output_flag 1 'combined capture output flag' -QO matches candidate
 assert_array_output_flag 1 'standalone display output flag' -D displays candidate
 assert_array_output_flag 1 'combined display output flag' -QD displays candidate
+assert_array_output_flag 1 'standalone transformed output flag' -A matches candidate
+assert_array_output_flag 1 'combined transformed output flag' -QA matches candidate
 assert_array_output_flag 0 'output flag after option terminator is a candidate' - -O
 assert_array_output_flag 0 'option value containing O is not an output flag' -P -Output candidate
+assert_array_output_flag 0 'option value containing A is not an output flag' -P -Array candidate
 
 assert_path_kind() {
     local expected=$1 path=$2 description=$3

--- a/shell/tests/compsys_state.zsh
+++ b/shell/tests/compsys_state.zsh
@@ -43,9 +43,17 @@ RPROMPT=""
 
 run_case() {
     local case_name=$1 expected=$2
+    local saved_zdotdir=${ZDOTDIR-}
+    local -i had_zdotdir=$+ZDOTDIR
     : > "$ZACRS_STATE_MARKER"
     export ZACRS_STATE_CASE=$case_name
-    ZDOTDIR="$tmp_dir" zpty -b zacrs_compsys_state zsh -d
+    export ZDOTDIR="$tmp_dir"
+    zpty -b zacrs_compsys_state zsh -d
+    if (( had_zdotdir )); then
+        export ZDOTDIR=$saved_zdotdir
+    else
+        unset ZDOTDIR
+    fi
 
     local output="" chunk="" i
     for (( i = 0; i < 200; i++ )); do
@@ -55,6 +63,7 @@ run_case() {
     done
     if [[ "$output" != *"READY> "* ]]; then
         print -u2 -r -- "not ok: child zsh did not become ready for $case_name"
+        print -u2 -r -- "pty: ${(qqq)output}"
         return 1
     fi
 

--- a/shell/tests/compsys_state.zsh
+++ b/shell/tests/compsys_state.zsh
@@ -1,0 +1,82 @@
+#!/usr/bin/env zsh
+
+set -eu
+
+zmodload zsh/zpty
+
+typeset test_dir="${0:A:h}"
+typeset tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/zacrs-compsys-state.XXXXXX")"
+trap 'zpty -d 2>/dev/null || true; rm -rf -- "$tmp_dir"' EXIT
+
+export ZACRS_STATE_COMPSYS="${test_dir:h}/_zacrs_compsys.zsh"
+export ZACRS_STATE_UTIL="${test_dir:h}/_zacrs_util.zsh"
+export ZACRS_STATE_MARKER="$tmp_dir/marker"
+
+print -r -- '
+autoload -Uz compinit
+compinit -C
+source "$ZACRS_STATE_UTIL"
+source "$ZACRS_STATE_COMPSYS"
+
+_zacrs_state_test_completion() {
+    local -i before=$compstate[nmatches] compadd_status=0 after
+    local -a candidates
+
+    case "$ZACRS_STATE_CASE" in
+        zero) candidates=(zzz) ;;
+        one) candidates=(xone) ;;
+        many) candidates=(x{001..200}) ;;
+    esac
+
+    compadd -- "${candidates[@]}" || compadd_status=$?
+    after=$compstate[nmatches]
+    print -r -- "$ZACRS_STATE_CASE status=$compadd_status delta=$(( after - before )) captured=${#_zacrs_captured} first=${_zacrs_captured[1]-}" > "$ZACRS_STATE_MARKER"
+    return $compadd_status
+}
+
+compdef _zacrs_state_test_completion zacrs-state-test
+bindkey -M emacs "^T" _zacrs_compsys
+bindkey -M viins "^T" _zacrs_compsys
+PROMPT="READY> "
+RPROMPT=""
+' > "$tmp_dir/.zshrc"
+
+run_case() {
+    local case_name=$1 expected=$2
+    : > "$ZACRS_STATE_MARKER"
+    export ZACRS_STATE_CASE=$case_name
+    ZDOTDIR="$tmp_dir" zpty -b zacrs_compsys_state zsh -d
+
+    local output="" chunk="" i
+    for (( i = 0; i < 200; i++ )); do
+        zpty -r -t zacrs_compsys_state chunk 2>/dev/null && output+="$chunk"
+        [[ "$output" == *"READY> "* ]] && break
+        sleep 0.01
+    done
+    if [[ "$output" != *"READY> "* ]]; then
+        print -u2 -r -- "not ok: child zsh did not become ready for $case_name"
+        return 1
+    fi
+
+    zpty -w -n zacrs_compsys_state $'zacrs-state-test x\x14'
+    for (( i = 0; i < 200; i++ )); do
+        [[ "$(<"$ZACRS_STATE_MARKER")" == "$expected" ]] && break
+        sleep 0.01
+    done
+
+    local actual="$(<"$ZACRS_STATE_MARKER")"
+    while zpty -r -t zacrs_compsys_state chunk 2>/dev/null; do
+        output+="$chunk"
+    done
+    zpty -d zacrs_compsys_state 2>/dev/null || true
+    if [[ "$actual" != "$expected" ]]; then
+        print -u2 -r -- "not ok: $case_name (expected=${(qqq)expected}, actual=${(qqq)actual})"
+        print -u2 -r -- "pty: ${(qqq)output}"
+        return 1
+    fi
+    print -r -- "ok: $case_name preserves compadd status and match state"
+}
+
+run_case zero 'zero status=1 delta=0 captured=0 first='
+run_case one $'one status=0 delta=1 captured=1 first=xone\t\t'
+run_case many $'many status=0 delta=101 captured=200 first=x001\t\t'


### PR DESCRIPTION
## Summary

- capture regular compsys candidates with `builtin compadd -O` without adding
  the same matches back to zsh's native completion list
- continue forwarding internal `-O` / `-D` probe calls so completion functions
  can populate and inspect their requested arrays
- keep zacrs's existing suppression of native insertion/list rendering

## Why

zacrs renders its own popup, so re-adding every captured match to the native zsh
completion list is redundant. With large file candidate sets this dominated the
completion time: the reproduced `source ` case dropped from about 20.55 seconds
to about 0.45 seconds while popup display, prefix filtering, Tab navigation, and
Enter confirmation continued to work.

This is a partial fix related to #126. Expensive dynamic sources such as
`yay -S` can still block because auto-popup synchronously reruns candidate
generation while input advances; #126 remains open for that broader collection
and cancellation work.

## Verification

- `CARGO_TARGET_DIR=target cargo test -q`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `zsh shell/tests/compsys_options.zsh`
- `zsh shell/tests/protocol.zsh`
- `zsh -n shell/_zacrs_util.zsh shell/_zacrs_compsys.zsh shell/_zacrs_protocol.zsh shell/zsh-autocomplete-rs.plugin.zsh`
- `git diff --check`
- interactive `source ` popup, filtering, Tab selection, and Enter confirmation
