### PR TITLE
feat(abbr): support command-context conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +599,19 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1152,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2074,6 +2097,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "frizbee",
+ "globset",
  "libc",
  "serde",
  "termwiz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ dirs = "6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 termwiz = "0.23"
+globset = "0.4"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
@@ -62,6 +63,10 @@ harness = false
 
 [[bench]]
 name = "rendering_bench"
+harness = false
+
+[[bench]]
+name = "abbr_when_bench"
 harness = false
 
 [profile.release]

--- a/benches/abbr_when_bench.rs
+++ b/benches/abbr_when_bench.rs
@@ -1,0 +1,37 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+use zsh_autocomplete_rs::config::{Abbreviation, AbbreviationPosition, AbbreviationWhen};
+
+fn abbreviations(count: usize) -> Vec<Abbreviation> {
+    (0..count)
+        .map(|index| Abbreviation {
+            trigger: format!("abbr-{index}"),
+            expansion: format!("expansion-{index}"),
+            description: String::new(),
+            when: AbbreviationWhen::with_command_patterns(
+                AbbreviationPosition::Argument,
+                vec![format!("command-{index} *")],
+            )
+            .unwrap(),
+        })
+        .collect()
+}
+
+fn bench_command_globs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("abbreviation_when_command");
+    for count in [10, 100, 1_000] {
+        let abbreviations = abbreviations(count);
+        group.bench_with_input(BenchmarkId::new("no_match", count), &count, |b, _| {
+            b.iter(|| {
+                abbreviations
+                    .iter()
+                    .filter(|abbr| abbr.is_available_at(false, Some(black_box("cargo test null"))))
+                    .count()
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_command_globs);
+criterion_main!(benches);

--- a/benches/protocol_bench.rs
+++ b/benches/protocol_bench.rs
@@ -31,6 +31,7 @@ fn make_render_request(candidate_count: usize) -> Request {
         candidates_tsv: tsv,
         selected: Some(0),
         command_position: false,
+        command_context: None,
     }
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,27 @@ when.position = "any"
 `when.position = "any"` also offers the abbreviation at argument positions. Typing
 `cargo test <Tab>` can then show `null`, and `cargo test null<Tab>` can replace
 `null` with `>/dev/null`. The supported positions are `command` (the default)
-and `any`.
+`argument`, and `any`.
+
+Use `when.command` to restrict an abbreviation to the current simple-command
+context. It accepts one glob or a list of alternative globs:
+
+```toml
+[[abbreviation]]
+trigger = "null"
+expansion = ">/dev/null"
+description = "discard stdout"
+when.position = "argument"
+when.command = ["cargo *", "cross *", "git add *"]
+```
+
+The shell normalizes parsed words to one space and matches only the simple
+command containing the cursor, so `echo ok | cargo test null` is matched as
+`cargo test null`. Matching is case-sensitive and anchored to the entire
+context. Patterns support `*`, `?`, and character classes such as `[abc]`.
+They are compiled when configuration is loaded and are never expanded or
+executed by the shell. Position and command conditions are combined with AND;
+entries in the command list are combined with OR.
 
 `{{cursor}}` is removed during insertion and places the cursor at that position.
 Only one cursor marker is supported per expansion.

--- a/shell/_zacrs_util.zsh
+++ b/shell/_zacrs_util.zsh
@@ -53,6 +53,37 @@ _zacrs_is_cmd_pos() {
     return 1
 }
 
+# Return the current simple-command context through the cursor, normalized to
+# one space between parsed words. Separators start a new simple command. A
+# trailing blank is preserved so patterns such as "cargo *" match a new
+# argument position before any prefix has been typed.
+# Args: $1=LBUFFER. Sets REPLY and _zacrs_command_context_is_command; returns 1
+# when Zsh cannot tokenize the buffer.
+_zacrs_command_context() {
+    local _buffer="$1"
+    local -a _tokens _segment
+    typeset -g _zacrs_command_context_is_command=0
+    _tokens=( ${(z)_buffer} ) 2>/dev/null || { REPLY=""; return 1; }
+
+    local _token
+    for _token in "${_tokens[@]}"; do
+        if [[ "$_token" == ('|'|'|&'|'||'|'&&'|'&'|';'|$'\n') ]]; then
+            _segment=()
+        else
+            _segment+=("${(Q)_token}")
+        fi
+    done
+
+    REPLY="${(j: :)_segment}"
+    if [[ "$_buffer" == *[[:space:]] ]]; then
+        REPLY+=" "
+        (( ${#_segment} == 0 )) && _zacrs_command_context_is_command=1
+    else
+        (( ${#_segment} <= 1 )) && _zacrs_command_context_is_command=1
+    fi
+    return 0
+}
+
 # Render even when compsys produced no candidates. The Rust side may still
 # contribute configured abbreviations at any command-line position.
 # Args: $1=candidates $2=buffer $3=prefix

--- a/shell/tests/compsys_options.zsh
+++ b/shell/tests/compsys_options.zsh
@@ -94,4 +94,36 @@ assert_render_gate 1 '' gpo gpo 'command position reaches configured abbreviatio
 assert_render_gate 1 '' 'git gpo' gpo 'argument position reaches configured abbreviations without shell candidates'
 assert_render_gate 1 $'git\tcommand\tcommand' 'git gpo' gpo 'shell candidates render in argument position'
 
+assert_command_context() {
+    local expected=$1 buffer=$2 description=$3
+    local actual=""
+    if _zacrs_command_context "$buffer"; then
+        actual="$REPLY"
+    fi
+    if [[ "$actual" != "$expected" ]]; then
+        print -u2 -r -- "not ok: ${description} (expected=${expected}, actual=${actual})"
+        (( ++failures ))
+    else
+        print -r -- "ok: ${description}"
+    fi
+}
+
+assert_command_context 'cargo test nu' 'cargo    test  nu' 'command context normalizes spaces'
+assert_command_context 'cargo test nu' 'echo ok | cargo test nu' 'command context starts after pipe'
+assert_command_context 'cargo null' 'sleep 1 & cargo null' 'command context starts after background separator'
+assert_command_context 'cargo null' 'echo ok |& cargo null' 'command context starts after stderr pipe'
+assert_command_context 'git add ' 'cd repo && git add ' 'command context preserves a new argument slot'
+assert_command_context 'printf %s | nu' "printf '%s' '|' nu" 'quoted separator stays in command context'
+
+_zacrs_command_context 'sleep 1 & cargo'
+(( _zacrs_command_context_is_command == 1 )) || {
+    print -u2 -r -- 'not ok: first word after background separator is command position'
+    (( ++failures ))
+}
+_zacrs_command_context 'echo ok |& cargo'
+(( _zacrs_command_context_is_command == 1 )) || {
+    print -u2 -r -- 'not ok: first word after stderr pipe is command position'
+    (( ++failures ))
+}
+
 (( failures == 0 ))

--- a/shell/zsh-autocomplete-rs.plugin.zsh
+++ b/shell/zsh-autocomplete-rs.plugin.zsh
@@ -200,7 +200,7 @@ _zacrs_parse_render_header() {
 }
 
 # Connect to daemon, send a render request, and parse the response header.
-# Args: $1=cursor_row $2=cursor_col $3=prefix $4=candidates $5=selected (optional) $6=context_key (optional) $7=command-position (0|1) $8=candidates-present (0|1)
+# Args: $1=cursor_row $2=cursor_col $3=prefix $4=candidates $5=selected (optional) $6=context_key (optional) $7=command-position (0|1) $8=candidates-present (0|1) $9=command-context (optional)
 # When candidates are empty, $8 distinguishes an explicit empty candidate set
 # from a cache-only request. Cache-first and resize callers leave $8 unset.
 # On OK        (return 0): _zacrs_send_render_fd holds open fd; caller must sysread + close.
@@ -208,7 +208,7 @@ _zacrs_parse_render_header() {
 # On CACHE_MISS (return 3): fd already closed; caller should collect candidates and retry.
 # On ERROR/connect failure (return 2): fd already closed, daemon marked unavailable.
 _zacrs_daemon_send_render() {
-    local _cr="$1" _cc="$2" _pfx="$3" _cands="$4" _sel="${5:-}" _ctx_key="${6:-}" _cmd_pos="${7:-0}" _cands_present="${8:-0}"
+    local _cr="$1" _cc="$2" _pfx="$3" _cands="$4" _sel="${5:-}" _ctx_key="${6:-}" _cmd_pos="${7:-0}" _cands_present="${8:-0}" _command_context="${9:-}"
     local fd
     if ! zsocket "$_zacrs_socket_path" 2>/dev/null; then
         (( ${+functions[_zacrs_mark_daemon_unavailable]} )) && _zacrs_mark_daemon_unavailable
@@ -218,6 +218,7 @@ _zacrs_daemon_send_render() {
     local render_cmd="render $_cr $_cc $COLUMNS $LINES"
     [[ -n "$_ctx_key" ]] && render_cmd+=" context_key=$_ctx_key"
     (( _cmd_pos )) && render_cmd+=" command_position=1"
+    [[ -n "$_command_context" ]] && render_cmd+=" command_context_hex=$(_zacrs_encode_hex_input "$_command_context")"
     (( _cands_present )) && render_cmd+=" candidates_present=1"
     render_cmd+=" popup_key=$$"
     [[ -n "$_sel" ]] && render_cmd+=" selected=$_sel"
@@ -295,7 +296,11 @@ _zacrs_render() {
     local prefix="$1" prefix_len="$2" candidates_str="$3" from_gather="${4:-0}" selected="${5:-}" context_key="${6:-}"
     local cursor_row=0 cursor_col=0
     local is_cmd_pos=0
-    _zacrs_is_cmd_pos "$LBUFFER" "$prefix" && is_cmd_pos=1
+    local command_context=""
+    if _zacrs_command_context "$LBUFFER"; then
+        command_context="$REPLY"
+        is_cmd_pos=$_zacrs_command_context_is_command
+    fi
     # When the popup is already on screen and the terminal hasn't resized,
     # reuse the previous cursor position instead of querying the terminal.
     # This eliminates the \e[6n round-trip (an extra /dev/tty write + read
@@ -318,7 +323,7 @@ _zacrs_render() {
     # Try zsocket daemon path (no subprocess spawn)
     if (( _zacrs_daemon_available )); then
         local _prev_vis=$_zacrs_popup_visible _prev_row=$_zacrs_popup_row _prev_height=$_zacrs_popup_height
-        _zacrs_daemon_send_render "$cursor_row" "$cursor_col" "$prefix" "$candidates_str" "$selected" "$context_key" "$is_cmd_pos" 1
+        _zacrs_daemon_send_render "$cursor_row" "$cursor_col" "$prefix" "$candidates_str" "$selected" "$context_key" "$is_cmd_pos" 1 "$command_context"
         local _send_rc=$?
         if (( _send_rc == 0 )); then
             local fd=$_zacrs_send_render_fd
@@ -350,6 +355,7 @@ _zacrs_render() {
     local -a render_args
     render_args=(render --prefix "$prefix" --cursor-row "$cursor_row" --cursor-col "$cursor_col")
     (( is_cmd_pos )) && render_args+=(--command-position)
+    [[ -n "$command_context" ]] && render_args+=(--command-context "$command_context")
     [[ -n "$selected" ]] && render_args+=(--selected "$selected")
     local output
     output=$(printf '%s' "$candidates_str" | "$ZACRS_BIN" "${render_args[@]}")
@@ -468,7 +474,11 @@ _zacrs_invoke_daemon() {
     local cursor_row="${4:-}" cursor_col="${5:-}" reuse_visible="${6:-0}" context_key="${7:-}" accept_single="${8:-0}" candidates_present="${9:-0}"
     local shift_tab_hex=""
     local is_cmd_pos=0
-    _zacrs_is_cmd_pos "$LBUFFER" "$prefix" && is_cmd_pos=1
+    local command_context=""
+    if _zacrs_command_context "$LBUFFER"; then
+        command_context="$REPLY"
+        is_cmd_pos=$_zacrs_command_context_is_command
+    fi
     if [[ -z "$cursor_row" || -z "$cursor_col" ]]; then
         cursor_row=0 cursor_col=0
         _zacrs_get_cursor_pos
@@ -489,6 +499,7 @@ _zacrs_invoke_daemon() {
         --popup-key "$$"
     )
     (( is_cmd_pos )) && complete_args+=(--command-position)
+    [[ -n "$command_context" ]] && complete_args+=(--command-context "$command_context")
     (( accept_single )) && complete_args+=(--accept-single)
     (( candidates_present )) && complete_args+=(--candidates-present)
     [[ -n "$shift_tab_hex" ]] && complete_args+=(--shift-tab-hex "$shift_tab_hex")
@@ -539,7 +550,11 @@ _zacrs_invoke() {
     local cursor_row="${4:-}" cursor_col="${5:-}" accept_single="${6:-0}"
     local shift_tab_hex=""
     local is_cmd_pos=0
-    _zacrs_is_cmd_pos "$LBUFFER" "$prefix" && is_cmd_pos=1
+    local command_context=""
+    if _zacrs_command_context "$LBUFFER"; then
+        command_context="$REPLY"
+        is_cmd_pos=$_zacrs_command_context_is_command
+    fi
     if [[ -z "$cursor_row" || -z "$cursor_col" ]]; then
         cursor_row=0 cursor_col=0
         _zacrs_get_cursor_pos
@@ -558,6 +573,7 @@ _zacrs_invoke() {
         --rows "$LINES"
     )
     (( is_cmd_pos )) && complete_args+=(--command-position)
+    [[ -n "$command_context" ]] && complete_args+=(--command-context "$command_context")
     (( accept_single )) && complete_args+=(--accept-single)
     [[ -n "$shift_tab_hex" ]] && complete_args+=(--shift-tab-hex "$shift_tab_hex")
     [[ -n "$stale_hex" ]] && complete_args+=(--stale-hex "$stale_hex")
@@ -777,6 +793,11 @@ _zacrs_line_pre_redraw() {
     local prefix prefix_len
     prefix="$naive_prefix"
     prefix_len=${#naive_prefix}
+    local command_context="" is_cmd_pos=0
+    if _zacrs_command_context "$LBUFFER"; then
+        command_context="$REPLY"
+        is_cmd_pos=$_zacrs_command_context_is_command
+    fi
 
     if (( !_zacrs_daemon_available )) && (( ${+functions[_zacrs_maybe_retry_daemon]} )); then
         _zacrs_maybe_retry_daemon
@@ -798,7 +819,7 @@ _zacrs_line_pre_redraw() {
         fi
         local _prev_vis=$_zacrs_popup_visible _prev_row=$_zacrs_popup_row _prev_height=$_zacrs_popup_height
         # candidates 引数を空にして送信 → デーモンがキャッシュを探す
-        _zacrs_daemon_send_render "$cursor_row" "$cursor_col" "$naive_prefix" "" "" "$context_key"
+        _zacrs_daemon_send_render "$cursor_row" "$cursor_col" "$naive_prefix" "" "" "$context_key" "$is_cmd_pos" 0 "$command_context"
         local _cache_rc=$?
         if (( _cache_rc == 0 )); then
             # キャッシュヒット: 描画完了
@@ -937,9 +958,12 @@ TRAPWINCH() {
     if (( _zacrs_popup_visible && _zacrs_daemon_available )) \
         && [[ "$_zacrs_popup_snapshot_lbuffer" == "$LBUFFER" ]] \
         && (( _zacrs_popup_snapshot_columns == COLUMNS )); then
-        local _resize_prefix="${LBUFFER##* }" _resize_cmd_pos=0
-        _zacrs_is_cmd_pos "$LBUFFER" "$_resize_prefix" && _resize_cmd_pos=1
-        _zacrs_daemon_send_render "$_zacrs_popup_cursor_row" "$_zacrs_last_render_cursor_col" "" "" "" "" "$_resize_cmd_pos"
+        local _resize_prefix="${LBUFFER##* }" _resize_cmd_pos=0 _resize_context=""
+        if _zacrs_command_context "$LBUFFER"; then
+            _resize_context="$REPLY"
+            _resize_cmd_pos=$_zacrs_command_context_is_command
+        fi
+        _zacrs_daemon_send_render "$_zacrs_popup_cursor_row" "$_zacrs_last_render_cursor_col" "" "" "" "" "$_resize_cmd_pos" 0 "$_resize_context"
         if (( $? == 0 )); then
             local fd=$_zacrs_send_render_fd
             local tty_len=$_zacrs_parsed_tty_len

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,9 @@ pub enum Command {
         #[arg(long, default_value_t = false)]
         command_position: bool,
 
+        #[arg(long)]
+        command_context: Option<String>,
+
         #[arg(long, default_value_t = false)]
         accept_single: bool,
 
@@ -77,6 +80,9 @@ pub enum Command {
 
         #[arg(long, default_value_t = false)]
         command_position: bool,
+
+        #[arg(long)]
+        command_context: Option<String>,
 
         /// Pre-select the N-th filtered candidate (0-indexed)
         #[arg(long)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,6 +28,7 @@ pub fn try_daemon_render(
     cursor_col: u16,
     selected: Option<usize>,
     command_position: bool,
+    command_context: Option<&str>,
     candidates_raw: &[u8],
 ) -> Result<RenderResponse, DaemonUnavailable> {
     let (term_cols, term_rows) = crossterm::terminal::size().unwrap_or((80, 24));
@@ -41,6 +42,7 @@ pub fn try_daemon_render(
         candidates_tsv: candidates_raw.to_vec(),
         selected: selected.and_then(|s| u16::try_from(s).ok()),
         command_position,
+        command_context: command_context.map(str::to_string),
     };
 
     let response = send_request(&request)?;
@@ -88,6 +90,7 @@ pub fn try_daemon_complete(
     cursor_col: u16,
     candidates_tsv: &str,
     command_position: bool,
+    command_context: Option<&str>,
     accept_single: bool,
     candidates_present: bool,
     shift_tab_sequence: Option<Vec<u8>>,
@@ -113,6 +116,7 @@ pub fn try_daemon_complete(
         term_rows,
         prev_popup,
         command_position,
+        command_context: command_context.map(str::to_string),
         accept_single,
         candidates_present,
         reuse_token: reuse_token.map(str::to_string),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,15 @@
 use crossterm::style::Color;
+use globset::{Glob, GlobMatcher};
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
 
 use crate::input::Action;
+
+const MAX_COMMAND_GLOB_PATTERNS: usize = 256;
+const MAX_COMMAND_GLOB_BYTES: usize = 1024;
+const MAX_COMMAND_CONTEXT_BYTES: usize = 16 * 1024;
 
 fn config_path() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("zacrs").join("config.toml"))
@@ -67,7 +72,7 @@ struct ConfigFile {
     abbreviation: Vec<AbbreviationRaw>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Abbreviation {
     pub trigger: String,
     pub expansion: String,
@@ -75,23 +80,147 @@ pub struct Abbreviation {
     pub when: AbbreviationWhen,
 }
 
+impl PartialEq for Abbreviation {
+    fn eq(&self, other: &Self) -> bool {
+        self.trigger == other.trigger
+            && self.expansion == other.expansion
+            && self.description == other.description
+            && self.when == other.when
+    }
+}
+
+impl Eq for Abbreviation {}
+
 #[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum AbbreviationPosition {
     #[default]
     Command,
+    Argument,
     Any,
 }
 
-#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default)]
 pub struct AbbreviationWhen {
-    #[serde(default)]
     pub position: AbbreviationPosition,
+    command_patterns: Vec<String>,
+    command_matchers: Vec<GlobMatcher>,
 }
 
 impl Abbreviation {
-    pub fn is_available_at(&self, command_position: bool) -> bool {
-        command_position || self.when.position == AbbreviationPosition::Any
+    pub fn is_available_at(&self, command_position: bool, command_context: Option<&str>) -> bool {
+        let position_matches = match self.when.position {
+            AbbreviationPosition::Command => command_position,
+            AbbreviationPosition::Argument => !command_position,
+            AbbreviationPosition::Any => true,
+        };
+        if !position_matches {
+            return false;
+        }
+        self.when.matches_command(command_context)
+    }
+}
+
+impl PartialEq for AbbreviationWhen {
+    fn eq(&self, other: &Self) -> bool {
+        self.position == other.position && self.command_patterns == other.command_patterns
+    }
+}
+
+impl Eq for AbbreviationWhen {}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum OneOrMany {
+    One(String),
+    Many(Vec<String>),
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct AbbreviationWhenRaw {
+    #[serde(default)]
+    position: AbbreviationPosition,
+    command: Option<OneOrMany>,
+}
+
+impl<'de> Deserialize<'de> for AbbreviationWhen {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = AbbreviationWhenRaw::deserialize(deserializer)?;
+        let command_was_set = raw.command.is_some();
+        let command_patterns = match raw.command {
+            None => Vec::new(),
+            Some(OneOrMany::One(pattern)) => vec![pattern],
+            Some(OneOrMany::Many(patterns)) => patterns,
+        };
+        if command_patterns.is_empty() && command_was_set {
+            return Err(serde::de::Error::custom(
+                "when.command must contain at least one glob",
+            ));
+        }
+        if command_patterns.len() > MAX_COMMAND_GLOB_PATTERNS {
+            return Err(serde::de::Error::custom(format!(
+                "when.command accepts at most {MAX_COMMAND_GLOB_PATTERNS} globs"
+            )));
+        }
+        if let Some(pattern) = command_patterns
+            .iter()
+            .find(|pattern| pattern.len() > MAX_COMMAND_GLOB_BYTES)
+        {
+            return Err(serde::de::Error::custom(format!(
+                "when.command glob exceeds {MAX_COMMAND_GLOB_BYTES} bytes: {pattern}"
+            )));
+        }
+        let command_matchers = command_patterns
+            .iter()
+            .map(|pattern| {
+                Glob::new(pattern)
+                    .map(|glob| glob.compile_matcher())
+                    .map_err(serde::de::Error::custom)
+            })
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            position: raw.position,
+            command_patterns,
+            command_matchers,
+        })
+    }
+}
+
+impl AbbreviationWhen {
+    pub fn at_position(position: AbbreviationPosition) -> Self {
+        Self {
+            position,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_command_patterns(
+        position: AbbreviationPosition,
+        command_patterns: Vec<String>,
+    ) -> Result<Self, globset::Error> {
+        let command_matchers = command_patterns
+            .iter()
+            .map(|pattern| Glob::new(pattern).map(|glob| glob.compile_matcher()))
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            position,
+            command_patterns,
+            command_matchers,
+        })
+    }
+
+    fn matches_command(&self, command_context: Option<&str>) -> bool {
+        self.command_matchers.is_empty()
+            || command_context.is_some_and(|context| {
+                context.len() <= MAX_COMMAND_CONTEXT_BYTES
+                    && self
+                        .command_matchers
+                        .iter()
+                        .any(|matcher| matcher.is_match(context))
+            })
     }
 }
 
@@ -285,7 +414,7 @@ impl Config {
                     trigger: abbr.trigger.clone(),
                     expansion: abbr.expansion.clone(),
                     description: abbr.description.clone(),
-                    when: abbr.when,
+                    when: abbr.when.clone(),
                 },
             );
         }
@@ -610,10 +739,65 @@ when.position = "any"
                     description: String::new(),
                     when: AbbreviationWhen {
                         position: AbbreviationPosition::Any,
+                        ..Default::default()
                     },
                 },
             ]
         );
+    }
+
+    #[test]
+    fn abbreviation_when_command_accepts_one_or_many_globs() {
+        let file: ConfigFile = toml::from_str(
+            r#"
+[[abbreviation]]
+trigger = "null"
+expansion = ">/dev/null"
+when.position = "argument"
+when.command = ["cargo *", "git add *"]
+"#,
+        )
+        .unwrap();
+        let abbreviations = Config::abbreviations_from_file(&file);
+        let abbreviation = &abbreviations[0];
+
+        assert!(abbreviation.is_available_at(false, Some("cargo test null")));
+        assert!(abbreviation.is_available_at(false, Some("git add src null")));
+        assert!(!abbreviation.is_available_at(false, Some("git commit null")));
+        assert!(!abbreviation.is_available_at(true, Some("cargo test null")));
+        assert!(!abbreviation.is_available_at(false, None));
+    }
+
+    #[test]
+    fn abbreviation_when_command_glob_is_anchored() {
+        let file: ConfigFile = toml::from_str(
+            r#"
+[[abbreviation]]
+trigger = "null"
+expansion = ">/dev/null"
+when.position = "argument"
+when.command = "cargo *"
+"#,
+        )
+        .unwrap();
+        let abbreviation = &Config::abbreviations_from_file(&file)[0];
+
+        assert!(abbreviation.is_available_at(false, Some("cargo null")));
+        assert!(!abbreviation.is_available_at(false, Some("sudo cargo null")));
+    }
+
+    #[test]
+    fn abbreviation_when_rejects_invalid_command_glob() {
+        let parsed = toml::from_str::<ConfigFile>(
+            r#"
+[[abbreviation]]
+trigger = "null"
+expansion = ">/dev/null"
+when.command = "["
+"#,
+        );
+
+        assert!(parsed.is_err());
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -123,6 +123,7 @@ struct RenderParams {
     term_rows: u16,
     selected: Option<usize>,
     command_position: bool,
+    command_context: Option<String>,
 }
 
 struct CompleteParams {
@@ -134,6 +135,7 @@ struct CompleteParams {
     prev_popup_row: Option<u16>,
     prev_popup_height: Option<u16>,
     command_position: bool,
+    command_context: Option<String>,
     accept_single: bool,
     reuse_popup: bool,
     shift_tab_sequence: Option<Vec<u8>>,
@@ -209,6 +211,7 @@ pub fn run_stdio_complete<R: BufRead, W: Write>(
     term_cols: u16,
     term_rows: u16,
     command_position: bool,
+    command_context: Option<String>,
     accept_single: bool,
     shift_tab_sequence: Option<Vec<u8>>,
     prev_popup_row: Option<u16>,
@@ -239,6 +242,7 @@ pub fn run_stdio_complete<R: BufRead, W: Write>(
         prev_popup_row,
         prev_popup_height,
         command_position,
+        command_context,
         accept_single,
         reuse_popup: false,
         shift_tab_sequence,
@@ -445,6 +449,7 @@ impl DaemonServer {
                 candidates_tsv,
                 selected,
                 command_position,
+                command_context,
             } => {
                 let _span = info_span!(
                     "render",
@@ -467,6 +472,7 @@ impl DaemonServer {
                         term_rows,
                         selected: selected.map(usize::from),
                         command_position,
+                        command_context,
                     },
                     &candidates_tsv,
                 );
@@ -584,6 +590,7 @@ impl DaemonServer {
                 context_key,
                 popup_key,
                 command_position,
+                command_context,
                 candidates_present,
             }) => {
                 let (mut prefix, tsv_opt) =
@@ -605,6 +612,7 @@ impl DaemonServer {
                             term_rows,
                             selected,
                             command_position,
+                            command_context: command_context.clone(),
                         },
                         b"",
                     );
@@ -665,6 +673,7 @@ impl DaemonServer {
                                 term_rows,
                                 selected,
                                 command_position,
+                                command_context: command_context.clone(),
                             },
                             cached_tsv.as_bytes(),
                         );
@@ -713,6 +722,7 @@ impl DaemonServer {
                                     term_rows,
                                     selected,
                                     command_position,
+                                    command_context: command_context.clone(),
                                 },
                                 cached_tsv.as_bytes(),
                             );
@@ -781,6 +791,7 @@ impl DaemonServer {
                         term_rows,
                         selected,
                         command_position,
+                        command_context,
                     },
                     tsv.as_bytes(),
                 );
@@ -814,6 +825,7 @@ impl DaemonServer {
                 term_rows,
                 prev_popup,
                 command_position,
+                command_context,
                 accept_single,
                 candidates_present,
                 reuse_token,
@@ -916,6 +928,7 @@ impl DaemonServer {
                         prev_popup_row: prev_popup.map(|(row, _)| row),
                         prev_popup_height: prev_popup.map(|(_, height)| height),
                         command_position,
+                        command_context,
                         accept_single,
                         reuse_popup: reuse_token.is_some(),
                         shift_tab_sequence,
@@ -1015,8 +1028,8 @@ impl DaemonServer {
             term_rows,
             selected,
             command_position,
+            command_context,
         } = params;
-        let _ = command_position; // Retained in the wire protocol for compatibility.
         let tsv_str = match std::str::from_utf8(candidates_tsv) {
             Ok(s) => s,
             Err(e) => {
@@ -1035,7 +1048,7 @@ impl DaemonServer {
             self.config
                 .abbreviations
                 .iter()
-                .filter(|abbr| abbr.is_available_at(command_position))
+                .filter(|abbr| abbr.is_available_at(command_position, command_context.as_deref()))
                 .map(|abbr| {
                     Candidate::abbreviation(
                         abbr.trigger.clone(),
@@ -1139,6 +1152,7 @@ impl DaemonServer {
         term_rows: u16,
         tsv: &str,
         command_position: bool,
+        command_context: Option<&str>,
     ) -> Option<(App, Vec<u8>)> {
         let native_candidates_present = tsv.lines().any(|line| !line.is_empty());
         let mut candidates: Vec<Candidate> = tsv
@@ -1151,7 +1165,7 @@ impl DaemonServer {
             self.config
                 .abbreviations
                 .iter()
-                .filter(|abbr| abbr.is_available_at(command_position))
+                .filter(|abbr| abbr.is_available_at(command_position, command_context))
                 .map(|abbr| {
                     Candidate::abbreviation(
                         abbr.trigger.clone(),
@@ -1216,6 +1230,7 @@ impl DaemonServer {
             prev_popup_row,
             prev_popup_height,
             command_position,
+            command_context,
             accept_single,
             reuse_popup,
             shift_tab_sequence,
@@ -1230,6 +1245,7 @@ impl DaemonServer {
             term_rows,
             tsv,
             command_position,
+            command_context.as_deref(),
         ) {
             Some(v) => v,
             None => return,
@@ -1900,6 +1916,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -1950,6 +1967,7 @@ mod tests {
                 term_rows: 24,
                 selected: None,
                 command_position: false,
+                command_context: None,
             },
             b"git\tcommand\tcommand\ngrep\tcommand\tcommand\n",
         );
@@ -1973,6 +1991,7 @@ mod tests {
                 term_rows: 24,
                 selected: None,
                 command_position: false,
+                command_context: None,
             },
             b"git\tcommand\tcommand\n",
         );
@@ -2003,6 +2022,7 @@ mod tests {
                     term_rows: 24,
                     selected: None,
                     command_position: false,
+                    command_context: None,
                 },
                 b"git-log\tcommand\tcommand\ngit-status\tcommand\tcommand\n",
             );
@@ -2069,6 +2089,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2098,6 +2119,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2124,6 +2146,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: true,
                 shift_tab_sequence: None,
@@ -2151,6 +2174,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2188,6 +2212,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2221,6 +2246,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2261,6 +2287,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2297,6 +2324,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2335,6 +2363,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2362,6 +2391,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2398,6 +2428,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2440,6 +2471,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2488,6 +2520,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2535,6 +2568,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2571,6 +2605,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: true,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2592,9 +2627,9 @@ mod tests {
             trigger: "null".to_string(),
             expansion: ">/dev/null".to_string(),
             description: "discard stdout".to_string(),
-            when: crate::config::AbbreviationWhen {
-                position: crate::config::AbbreviationPosition::Any,
-            },
+            when: crate::config::AbbreviationWhen::at_position(
+                crate::config::AbbreviationPosition::Any,
+            ),
         }];
 
         let mut reader = BufReader::new(Cursor::new(Vec::<u8>::new()));
@@ -2611,6 +2646,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: true,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2643,6 +2679,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: true,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2668,9 +2705,9 @@ mod tests {
             trigger: "null".to_string(),
             expansion: ">/dev/null".to_string(),
             description: "discard stdout".to_string(),
-            when: crate::config::AbbreviationWhen {
-                position: crate::config::AbbreviationPosition::Any,
-            },
+            when: crate::config::AbbreviationWhen::at_position(
+                crate::config::AbbreviationPosition::Any,
+            ),
         }];
         let mut reader = Cursor::new(Vec::<u8>::new());
         let mut writer = Vec::new();
@@ -2687,6 +2724,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: true,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2696,6 +2734,56 @@ mod tests {
 
         let output = String::from_utf8(writer).unwrap();
         assert!(output.starts_with("DONE 0 >/dev/null\n"), "{output}");
+    }
+
+    #[test]
+    fn handle_complete_applies_command_glob_to_abbreviation() {
+        let mut server = test_server();
+        server.config.abbreviations = vec![crate::config::Abbreviation {
+            trigger: "null".to_string(),
+            expansion: ">/dev/null".to_string(),
+            description: "discard stdout".to_string(),
+            when: crate::config::AbbreviationWhen::with_command_patterns(
+                crate::config::AbbreviationPosition::Argument,
+                vec!["cargo *".to_string()],
+            )
+            .unwrap(),
+        }];
+
+        for (context, expected) in [
+            (Some("cargo test null"), true),
+            (Some("git test null"), false),
+            (None, false),
+        ] {
+            let mut reader = Cursor::new(Vec::<u8>::new());
+            let mut writer = Vec::new();
+            server.handle_complete(
+                &mut reader,
+                &mut writer,
+                CompleteParams {
+                    prefix: "null".to_string(),
+                    cursor_row: 5,
+                    cursor_col: 12,
+                    term_cols: 80,
+                    term_rows: 24,
+                    prev_popup_row: None,
+                    prev_popup_height: None,
+                    command_position: false,
+                    command_context: context.map(str::to_string),
+                    accept_single: true,
+                    reuse_popup: false,
+                    shift_tab_sequence: None,
+                },
+                "",
+            );
+
+            let output = String::from_utf8(writer).unwrap();
+            assert_eq!(
+                output.starts_with("DONE 0 >/dev/null\n"),
+                expected,
+                "{output}"
+            );
+        }
     }
 
     #[test]
@@ -2716,6 +2804,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: true,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2748,6 +2837,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: true,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2786,6 +2876,7 @@ mod tests {
                 term_rows: 24,
                 selected: None,
                 command_position: true,
+                command_context: None,
             },
             b"cargo\tcommand\tcommand\n",
         );
@@ -2808,9 +2899,9 @@ mod tests {
                 trigger: "null".to_string(),
                 expansion: ">/dev/null".to_string(),
                 description: "discard stdout".to_string(),
-                when: crate::config::AbbreviationWhen {
-                    position: crate::config::AbbreviationPosition::Any,
-                },
+                when: crate::config::AbbreviationWhen::at_position(
+                    crate::config::AbbreviationPosition::Any,
+                ),
             },
             crate::config::Abbreviation {
                 trigger: "gs".to_string(),
@@ -2829,6 +2920,7 @@ mod tests {
                 term_rows: 24,
                 selected: None,
                 command_position: false,
+                command_context: None,
             },
             b"--release\toption\toption\n",
         );
@@ -2897,6 +2989,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: true,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2937,6 +3030,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: true,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -2981,6 +3075,7 @@ mod tests {
                 prev_popup_row: None,
                 prev_popup_height: None,
                 command_position: false,
+                command_context: None,
                 accept_single: false,
                 reuse_popup: false,
                 shift_tab_sequence: None,
@@ -3184,6 +3279,7 @@ mod tests {
             term_rows: 24,
             prev_popup: None,
             command_position: false,
+            command_context: None,
             accept_single: true,
             candidates_present: false,
             reuse_token: Some("reuse-1".to_string()),
@@ -3221,6 +3317,7 @@ mod tests {
             term_rows: 24,
             prev_popup: None,
             command_position: false,
+            command_context: None,
             accept_single: true,
             candidates_present: false,
             reuse_token: Some("reuse-1".to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ struct CompleteCommand {
     rows: u16,
     daemon_mode: bool,
     command_position: bool,
+    command_context: Option<String>,
     accept_single: bool,
     candidates_present: bool,
     shift_tab_sequence: Option<Vec<u8>>,
@@ -73,6 +74,7 @@ fn run_complete(command: CompleteCommand) -> io::Result<()> {
         rows,
         daemon_mode,
         command_position,
+        command_context,
         accept_single,
         candidates_present,
         shift_tab_sequence,
@@ -97,6 +99,7 @@ fn run_complete(command: CompleteCommand) -> io::Result<()> {
             cursor_col,
             &tsv,
             command_position,
+            command_context.as_deref(),
             accept_single,
             candidates_present,
             shift_tab_sequence,
@@ -140,6 +143,7 @@ fn run_complete(command: CompleteCommand) -> io::Result<()> {
             cols,
             rows,
             command_position,
+            command_context,
             accept_single,
             shift_tab_for_thread,
             prev_popup_row,
@@ -174,6 +178,7 @@ fn run_render(
     cursor_col: u16,
     selected: Option<usize>,
     command_position: bool,
+    command_context: Option<String>,
     config: &config::Config,
 ) -> io::Result<i32> {
     // Read raw stdin before trying daemon (we need it for both paths)
@@ -190,6 +195,7 @@ fn run_render(
         cursor_col,
         selected,
         command_position,
+        command_context.as_deref(),
         &raw_stdin,
     ) {
         let mut tty = tty::open_tty_write()?;
@@ -212,7 +218,7 @@ fn run_render(
         config
             .abbreviations
             .iter()
-            .filter(|abbr| abbr.is_available_at(command_position))
+            .filter(|abbr| abbr.is_available_at(command_position, command_context.as_deref()))
             .map(|abbr| {
                 Candidate::abbreviation(
                     abbr.trigger.clone(),
@@ -298,6 +304,7 @@ fn main() {
             cursor_col,
             daemon,
             command_position,
+            command_context,
             accept_single,
             candidates_present,
             shift_tab_hex,
@@ -317,6 +324,7 @@ fn main() {
             rows,
             daemon_mode: daemon,
             command_position,
+            command_context,
             accept_single,
             candidates_present,
             shift_tab_sequence: shift_tab_hex
@@ -344,6 +352,7 @@ fn main() {
             cursor_col,
             selected,
             command_position,
+            command_context,
         } => {
             let cfg = config::Config::load();
             match run_render(
@@ -352,6 +361,7 @@ fn main() {
                 cursor_col,
                 selected,
                 command_position,
+                command_context,
                 &cfg,
             ) {
                 Ok(code) => process::exit(code),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -5,6 +5,7 @@ const CMD_RENDER: u8 = 0x01;
 const CMD_CLEAR: u8 = 0x02;
 const CMD_PING: u8 = 0x03;
 const CMD_SHUTDOWN: u8 = 0x04;
+const CMD_RENDER_V2: u8 = 0x05;
 
 // Response status bytes
 const STATUS_SUCCESS: u8 = 0x00;
@@ -26,6 +27,7 @@ pub enum Request {
         /// Pre-select the N-th filtered candidate before rendering.
         selected: Option<u16>,
         command_position: bool,
+        command_context: Option<String>,
     },
     Clear {
         popup_row: u16,
@@ -56,6 +58,7 @@ pub struct TextRenderRequest {
     pub context_key: Option<String>,
     pub popup_key: Option<String>,
     pub command_position: bool,
+    pub command_context: Option<String>,
     pub candidates_present: bool,
 }
 
@@ -67,6 +70,7 @@ pub struct TextCompleteRequest {
     pub term_rows: u16,
     pub prev_popup: Option<(u16, u16)>,
     pub command_position: bool,
+    pub command_context: Option<String>,
     pub accept_single: bool,
     pub candidates_present: bool,
     pub reuse_token: Option<String>,
@@ -174,8 +178,9 @@ impl Request {
                 candidates_tsv,
                 selected,
                 command_position,
+                command_context,
             } => {
-                payload.push(CMD_RENDER);
+                payload.push(CMD_RENDER_V2);
                 let prefix_bytes = prefix.as_bytes();
                 write_u16(&mut payload, prefix_bytes.len() as u16);
                 payload.extend_from_slice(prefix_bytes);
@@ -190,6 +195,9 @@ impl Request {
                 if let Some(sel) = selected {
                     write_u16(&mut payload, *sel);
                 }
+                let context = command_context.as_deref().unwrap_or("").as_bytes();
+                write_u32(&mut payload, context.len() as u32);
+                payload.extend_from_slice(context);
                 payload.extend_from_slice(candidates_tsv);
             }
             Request::Clear {
@@ -234,7 +242,7 @@ impl Request {
         let mut cursor = &buf[1..];
 
         match cmd {
-            CMD_RENDER => {
+            CMD_RENDER | CMD_RENDER_V2 => {
                 let prefix_len = read_u16(&mut cursor)? as usize;
                 if cursor.len() < prefix_len {
                     return Err(io::Error::new(
@@ -265,6 +273,27 @@ impl Request {
                     None
                 };
                 let command_position = flags & 0x02 != 0;
+                let command_context = if cmd == CMD_RENDER_V2 {
+                    let context_len = read_u32(&mut cursor)? as usize;
+                    if cursor.len() < context_len {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "command context length exceeds payload",
+                        ));
+                    }
+                    let (context_bytes, rest) = cursor.split_at(context_len);
+                    cursor = rest;
+                    if context_bytes.is_empty() {
+                        None
+                    } else {
+                        Some(
+                            String::from_utf8(context_bytes.to_vec())
+                                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                        )
+                    }
+                } else {
+                    None
+                };
                 let candidates_tsv = cursor.to_vec();
                 Ok(Request::Render {
                     prefix,
@@ -275,6 +304,7 @@ impl Request {
                     candidates_tsv,
                     selected,
                     command_position,
+                    command_context,
                 })
             }
             CMD_CLEAR => {
@@ -403,6 +433,7 @@ impl TextRequest {
                 let mut context_key = None;
                 let mut popup_key = None;
                 let mut command_position = false;
+                let mut command_context = None;
                 let mut candidates_present = false;
                 for token in rest {
                     if let Some(value) = token.strip_prefix("selected=") {
@@ -413,6 +444,9 @@ impl TextRequest {
                         popup_key = Some(value.to_string());
                     } else if let Some(value) = token.strip_prefix("command_position=") {
                         command_position = value == "1";
+                    } else if let Some(value) = token.strip_prefix("command_context_hex=") {
+                        command_context =
+                            decode_hex_bytes(value).and_then(|bytes| String::from_utf8(bytes).ok());
                     } else if let Some(value) = token.strip_prefix("candidates_present=") {
                         candidates_present = value == "1";
                     }
@@ -426,6 +460,7 @@ impl TextRequest {
                     context_key,
                     popup_key,
                     command_position,
+                    command_context,
                     candidates_present,
                 }))
             }
@@ -440,6 +475,7 @@ impl TextRequest {
                 let mut prev_popup_row = None;
                 let mut prev_popup_height = None;
                 let mut command_position = false;
+                let mut command_context = None;
                 let mut accept_single = false;
                 let mut candidates_present = false;
                 let mut reuse_token = None;
@@ -461,6 +497,9 @@ impl TextRequest {
                         popup_key = Some(value.to_string());
                     } else if let Some(value) = token.strip_prefix("command_position=") {
                         command_position = value == "1";
+                    } else if let Some(value) = token.strip_prefix("command_context_hex=") {
+                        command_context =
+                            decode_hex_bytes(value).and_then(|bytes| String::from_utf8(bytes).ok());
                     } else if let Some(value) = token.strip_prefix("accept_single=") {
                         accept_single = value == "1";
                     } else if let Some(value) = token.strip_prefix("candidates_present=") {
@@ -474,6 +513,7 @@ impl TextRequest {
                     term_rows: parse_u16_token(term_rows)?,
                     prev_popup: prev_popup_row.zip(prev_popup_height),
                     command_position,
+                    command_context,
                     accept_single,
                     candidates_present,
                     reuse_token,
@@ -535,6 +575,12 @@ impl TextCompleteRequest {
         }
         if self.command_position {
             line.push_str(" command_position=1");
+        }
+        if let Some(context) = &self.command_context {
+            line.push_str(&format!(
+                " command_context_hex={}",
+                encode_hex_bytes(context.as_bytes())
+            ));
         }
         if self.accept_single {
             line.push_str(" accept_single=1");
@@ -762,8 +808,10 @@ mod tests {
             candidates_tsv: b"git\tcommand\tcommand\ngrep\tcommand\tcommand\n".to_vec(),
             selected: None,
             command_position: false,
+            command_context: Some("cargo test gi".to_string()),
         };
         let bytes = req.serialize();
+        assert_eq!(bytes[4], CMD_RENDER_V2);
         let parsed = Request::deserialize(&mut &bytes[..]).unwrap();
         match parsed {
             Request::Render {
@@ -775,6 +823,7 @@ mod tests {
                 candidates_tsv,
                 selected,
                 command_position,
+                command_context,
             } => {
                 assert_eq!(prefix, "gi");
                 assert_eq!(cursor_row, 5);
@@ -784,6 +833,35 @@ mod tests {
                 assert!(candidates_tsv.starts_with(b"git\t"));
                 assert_eq!(selected, None);
                 assert!(!command_position);
+                assert_eq!(command_context.as_deref(), Some("cargo test gi"));
+            }
+            _ => panic!("expected Render"),
+        }
+    }
+
+    #[test]
+    fn legacy_render_request_keeps_candidate_payload_intact() {
+        let mut payload = vec![CMD_RENDER];
+        write_u16(&mut payload, 2);
+        payload.extend_from_slice(b"gi");
+        write_u16(&mut payload, 5);
+        write_u16(&mut payload, 2);
+        write_u16(&mut payload, 80);
+        write_u16(&mut payload, 24);
+        payload.push(0);
+        payload.extend_from_slice(b"git\tcommand\tcommand\n");
+        let mut bytes = Vec::new();
+        write_u32(&mut bytes, payload.len() as u32);
+        bytes.extend_from_slice(&payload);
+
+        match Request::deserialize(&mut &bytes[..]).unwrap() {
+            Request::Render {
+                command_context,
+                candidates_tsv,
+                ..
+            } => {
+                assert_eq!(command_context, None);
+                assert_eq!(candidates_tsv, b"git\tcommand\tcommand\n");
             }
             _ => panic!("expected Render"),
         }
@@ -800,6 +878,7 @@ mod tests {
             candidates_tsv: b"git\tcommand\tcommand\ngrep\tcommand\tcommand\n".to_vec(),
             selected: Some(1),
             command_position: true,
+            command_context: None,
         };
         let bytes = req.serialize();
         let parsed = Request::deserialize(&mut &bytes[..]).unwrap();
@@ -808,10 +887,12 @@ mod tests {
                 selected,
                 candidates_tsv,
                 command_position,
+                command_context,
                 ..
             } => {
                 assert_eq!(selected, Some(1));
                 assert!(command_position);
+                assert_eq!(command_context, None);
                 assert!(candidates_tsv.starts_with(b"git\t"));
             }
             _ => panic!("expected Render"),
@@ -1005,6 +1086,7 @@ mod tests {
             term_rows: 24,
             prev_popup: Some((6, 12)),
             command_position: true,
+            command_context: Some("cargo test null".to_string()),
             accept_single: true,
             candidates_present: true,
             reuse_token: Some("123".to_string()),
@@ -1034,6 +1116,7 @@ mod tests {
                 context_key: Some("ctx".to_string()),
                 popup_key: Some("popup".to_string()),
                 command_position: true,
+                command_context: None,
                 candidates_present: true,
             })
         );


### PR DESCRIPTION
## Summary

- add when.command glob conditions for context-sensitive abbreviations
- normalize the current Zsh simple-command context across pipelines, lists, background jobs, and stderr pipelines
- propagate command context through CLI, daemon, subprocess, cache, and render paths
- preserve the legacy binary render frame and add a versioned V2 frame
- add regression tests, documentation, and a Criterion benchmark

## Configuration

    [[abbreviation]]
    trigger = "null"
    expansion = ">/dev/null"
    description = "discard stdout"
    when.position = "argument"
    when.command = ["cargo *", "cross *", "git add *"]

Command patterns are anchored globs. A list is OR-matched; position and command conditions are AND-matched.

## Performance

No-match command-context benchmark:

- 10 abbreviations: about 199 ns
- 100 abbreviations: about 2.1 us
- 1,000 abbreviations: about 31 us

Globs are compiled when configuration is loaded. Pattern count, pattern size, and context size are bounded.

## Verification

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- 257 Rust tests passed
- 4 daemon socket tests were filtered because the sandbox rejects Unix socket creation with Operation not permitted
- zsh shell/tests/compsys_options.zsh
- zsh shell/tests/compsys_state.zsh
- zsh shell/tests/protocol.zsh
- zsh shell/tests/typeahead.zsh
- Zsh syntax checks
- manual daemon-path expansion with cargo test null<Tab>
- independent review found no remaining actionable regressions